### PR TITLE
feature 35: configurable JWT refresh token expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ REDIS_DB=0
 - `JWT_SECRET`: JWT secret key (required, must be changed from default in production)
 - `JWT_EXPIRE_TIME`: Access token expiry duration (required, e.g., `15m`, `1h`)
 - `JWT_ISSUER`: JWT issuer identifier (required)
+- `JWT_REFRESH_EXPIRE_TIME`: Refresh token expiry duration (optional, e.g., `30m`, `24h`). When unset it defaults to `JWT_EXPIRE_TIME * 2`.
 
 **Example**:
 
@@ -186,9 +187,11 @@ REDIS_DB=0
 JWT_SECRET=your-super-secret-jwt-key-here-change-in-production
 JWT_EXPIRE_TIME=15m
 JWT_ISSUER=myapp
+# Optional: override refresh token lifetime (defaults to JWT_EXPIRE_TIME * 2)
+JWT_REFRESH_EXPIRE_TIME=30m
 ```
 
-**Note**: Refresh tokens expire after `JWT_EXPIRE_TIME * 24` (e.g., 15m * 24 = 6 hours).
+**Note**: Refresh tokens expire after `JWT_REFRESH_EXPIRE_TIME` when set, otherwise `JWT_EXPIRE_TIME * 2` (e.g., 15m * 2 = 30 minutes).
 
 ### I18N Configuration
 

--- a/config/jwt.go
+++ b/config/jwt.go
@@ -2,14 +2,30 @@ package config
 
 import "time"
 
+// defaultRefreshExpireMultiplier is the fallback multiplier applied to
+// ExpireTime when RefreshExpireTime is not explicitly configured.
+const defaultRefreshExpireMultiplier = 2
+
 type JWTConfig struct {
 	Secret     string        `env:"JWT_SECRET"`
 	ExpireTime time.Duration `env:"JWT_EXPIRE_TIME"`
 	Issuer     string        `env:"JWT_ISSUER"`
+	// RefreshExpireTime is the refresh token lifetime. Optional: when unset
+	// (zero) it defaults to ExpireTime * defaultRefreshExpireMultiplier.
+	RefreshExpireTime time.Duration `env:"JWT_REFRESH_EXPIRE_TIME,omitempty"`
 }
 
 func (s *JWTConfig) Key() string {
 	return "jwt"
+}
+
+// RefreshExpireOrDefault returns the configured refresh token lifetime, or the
+// default (ExpireTime * defaultRefreshExpireMultiplier) when it is not set.
+func (s *JWTConfig) RefreshExpireOrDefault() time.Duration {
+	if s.RefreshExpireTime > 0 {
+		return s.RefreshExpireTime
+	}
+	return s.ExpireTime * defaultRefreshExpireMultiplier
 }
 
 func (s *JWTConfig) Validate() error {
@@ -27,6 +43,10 @@ func (s *JWTConfig) Validate() error {
 
 	if s.ExpireTime <= 0 {
 		return NewConfigError("JWT_EXPIRE_TIME must be positive")
+	}
+
+	if s.RefreshExpireTime < 0 {
+		return NewConfigError("JWT_REFRESH_EXPIRE_TIME must not be negative")
 	}
 
 	if s.Issuer == "" {

--- a/config/jwt_test.go
+++ b/config/jwt_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJWTConfig_RefreshExpireOrDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		expire     time.Duration
+		refresh    time.Duration
+		wantResult time.Duration
+	}{
+		{
+			name:       "defaults to ExpireTime * 2 when unset",
+			expire:     15 * time.Minute,
+			refresh:    0,
+			wantResult: 30 * time.Minute,
+		},
+		{
+			name:       "uses configured value when set",
+			expire:     15 * time.Minute,
+			refresh:    24 * time.Hour,
+			wantResult: 24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &JWTConfig{ExpireTime: tt.expire, RefreshExpireTime: tt.refresh}
+			if got := cfg.RefreshExpireOrDefault(); got != tt.wantResult {
+				t.Errorf("RefreshExpireOrDefault() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestJWTConfig_Validate_RefreshExpireTime(t *testing.T) {
+	base := func() *JWTConfig {
+		return &JWTConfig{
+			Secret:     "a-non-default-secret",
+			ExpireTime: 15 * time.Minute,
+			Issuer:     "myapp",
+		}
+	}
+
+	t.Run("unset refresh is valid", func(t *testing.T) {
+		if err := base().Validate(); err != nil {
+			t.Errorf("expected valid config, got error: %v", err)
+		}
+	})
+
+	t.Run("positive refresh is valid", func(t *testing.T) {
+		cfg := base()
+		cfg.RefreshExpireTime = time.Hour
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected valid config, got error: %v", err)
+		}
+	})
+
+	t.Run("negative refresh is rejected", func(t *testing.T) {
+		cfg := base()
+		cfg.RefreshExpireTime = -time.Hour
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for negative JWT_REFRESH_EXPIRE_TIME, got nil")
+		}
+	})
+}

--- a/feature/jwt.go
+++ b/feature/jwt.go
@@ -172,7 +172,7 @@ func (f *jwtFeature) ExtractUserID(tokenString string) (int64, error) {
 
 func (f *jwtFeature) generateRefreshToken(userID int64, email string, features []string) (string, error) {
 	now := time.Now()
-	refreshExpire := f.Config.ExpireTime * 24
+	refreshExpire := f.Config.RefreshExpireOrDefault()
 
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/sample/full_showcase/.env
+++ b/sample/full_showcase/.env
@@ -67,6 +67,9 @@ JWT_SECRET=your-super-secret-jwt-key-change-in-production
 # Examples: 24h (24 hours), 720h (30 days), 168h (7 days)
 JWT_EXPIRE_TIME=24h
 
+# Refresh token expiry (optional; defaults to JWT_EXPIRE_TIME * 2 when unset)
+# JWT_REFRESH_EXPIRE_TIME=48h
+
 # JWT issuer
 JWT_ISSUER=sample-service
 

--- a/sample/full_showcase/README.md
+++ b/sample/full_showcase/README.md
@@ -141,6 +141,7 @@ Redis is required for JWT token blacklist.
 |----------|-------------|---------|
 | `JWT_SECRET` | Secret (change in production) | — |
 | `JWT_EXPIRE_TIME` | Token TTL, e.g. `24h`, `168h` | `24h` |
+| `JWT_REFRESH_EXPIRE_TIME` | Refresh token TTL (optional; defaults to `JWT_EXPIRE_TIME * 2`) | — |
 | `JWT_ISSUER` | Issuer | `sample-service` |
 
 ### I18N (optional)


### PR DESCRIPTION
## What

Make the JWT refresh token lifetime configurable instead of the hardcoded `ExpireTime * 24` in `feature/jwt.go`.

## Changes

- **config/jwt.go**: new optional field `RefreshExpireTime` (`env:"JWT_REFRESH_EXPIRE_TIME,omitempty"`) + `RefreshExpireOrDefault()` helper. `Validate()` rejects a negative value.
- **feature/jwt.go**: `generateRefreshToken` now uses `f.Config.RefreshExpireOrDefault()`.
- **docs**: README + `sample/full_showcase` `.env`/README document the new var.
- **tests**: `config/jwt_test.go` covers the default fallback and validation.

## Behavior

- `JWT_REFRESH_EXPIRE_TIME` set  → refresh token uses that duration.
- unset → defaults to `JWT_EXPIRE_TIME * 2`.

## ⚠️ Breaking change

The **default** refresh lifetime changes from `ExpireTime * 24` to `ExpireTime * 2`. Deployments that don't set `JWT_REFRESH_EXPIRE_TIME` will get shorter-lived refresh tokens. To preserve the old behavior, set `JWT_REFRESH_EXPIRE_TIME` explicitly (e.g. `JWT_EXPIRE_TIME=15m` → set `JWT_REFRESH_EXPIRE_TIME=6h`).

## Verification

`go build ./...`, `go vet`, and `go test ./config/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)