### PR TITLE
fix(jwt): 给 token 加 jti,修同一秒内签发的 token 完全相同

### DIFF
--- a/feature/jwt.go
+++ b/feature/jwt.go
@@ -2,6 +2,8 @@ package feature
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -94,12 +96,35 @@ func (f *jwtFeature) GenerateToken(userID int64, email string, features []string
 	}, nil
 }
 
+// newTokenID 生成 jti(JWT ID):128 bit 随机,十六进制。
+//
+// 为什么必须有:除了时间戳,claims 里其余字段(issuer/subject/user_id/email/features)对同一个
+// 用户都是固定的,而 NumericDate 只精确到**秒**。没有 jti 的话,同一用户在同一秒内签发的两个
+// token 会**字节完全相同** —— 它们在密码学意义上就是同一个凭据。后果:
+//   - 按 token 拉黑的登出:登出一台设备,同秒登录的另一台也一起掉线;
+//   - 上层按 token 哈希做的会话管理(如登录设备数限制)根本没法区分两台设备。
+//
+// 用 crypto/rand 而不是 math/rand:token 标识必须不可预测,且这里不引入新依赖。
+func newTokenID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate token id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
 func (f *jwtFeature) generateAccessToken(userID int64, email string, features []string) (string, error) {
 	now := time.Now()
 	expiresAt := now.Add(f.Config.ExpireTime)
 
+	tokenID, err := newTokenID()
+	if err != nil {
+		return "", err
+	}
+
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        tokenID,
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
@@ -174,8 +199,14 @@ func (f *jwtFeature) generateRefreshToken(userID int64, email string, features [
 	now := time.Now()
 	refreshExpire := f.Config.RefreshExpireOrDefault()
 
+	tokenID, err := newTokenID()
+	if err != nil {
+		return "", err
+	}
+
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        tokenID,
 			ExpiresAt: jwt.NewNumericDate(now.Add(refreshExpire)),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),

--- a/feature/jwt_test.go
+++ b/feature/jwt_test.go
@@ -1,0 +1,156 @@
+package feature
+
+import (
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+
+	"github.com/shyandsy/aurora/config"
+)
+
+func testJWT() *jwtFeature {
+	return &jwtFeature{
+		Config: &config.JWTConfig{
+			Secret:            "test-secret",
+			Issuer:            "aurora-test",
+			ExpireTime:        30 * time.Minute,
+			RefreshExpireTime: 24 * time.Hour,
+		},
+	}
+}
+
+// 同一用户在同一秒内签发的 token 必须各不相同。
+//
+// 为什么这条值得单独钉住:除时间戳外,claims 里其余字段(issuer/subject/user_id/email/features)
+// 对同一用户都是固定的,而 NumericDate 只精确到**秒**。在加入 jti 之前,同一秒内连签两个 token
+// 会得到**字节完全相同**的结果 —— 它们就是同一个凭据。真实后果:
+//   - Logout 按 token 字符串拉黑:登出一台设备,同秒登录的另一台一起掉线;
+//   - 上层按 token 哈希做的会话管理(如登录设备数限制)完全无法区分两台设备。
+//
+// 这个测试在加 jti 之前必然失败。
+func TestGenerateToken_SameSecondTokensAreUnique(t *testing.T) {
+	f := testJWT()
+
+	const n = 20
+	seenAccess := make(map[string]bool, n)
+	seenRefresh := make(map[string]bool, n)
+
+	// 连续快速签发:必然落在同一秒内,正是从前会碰撞的场景。
+	for i := 0; i < n; i++ {
+		resp, err := f.GenerateToken(42, "user@example.com", []string{})
+		if err != nil {
+			t.Fatalf("GenerateToken 失败: %v", err)
+		}
+		if seenAccess[resp.AccessToken] {
+			t.Fatalf("第 %d 次签发的 access token 与之前某个完全相同 —— "+
+				"同一秒登录的两台设备会共用一个凭据,登出/踢下线时会互相牵连", i+1)
+		}
+		if seenRefresh[resp.RefreshToken] {
+			t.Fatalf("第 %d 次签发的 refresh token 与之前某个完全相同", i+1)
+		}
+		seenAccess[resp.AccessToken] = true
+		seenRefresh[resp.RefreshToken] = true
+	}
+}
+
+// access token 与 refresh token 之间也不能相同(它们 claims 只差过期时间,同样有碰撞风险)。
+func TestGenerateToken_AccessAndRefreshDiffer(t *testing.T) {
+	f := testJWT()
+	resp, err := f.GenerateToken(42, "user@example.com", []string{})
+	if err != nil {
+		t.Fatalf("GenerateToken 失败: %v", err)
+	}
+	if resp.AccessToken == resp.RefreshToken {
+		t.Fatal("access 与 refresh token 相同 —— 拿 access 就能当 refresh 用")
+	}
+}
+
+// 签出来的 token 必须带 jti,且两次不同。
+func TestGenerateToken_HasUniqueJTI(t *testing.T) {
+	f := testJWT()
+
+	first, err := f.GenerateToken(1, "a@example.com", nil)
+	if err != nil {
+		t.Fatalf("GenerateToken 失败: %v", err)
+	}
+	second, err := f.GenerateToken(1, "a@example.com", nil)
+	if err != nil {
+		t.Fatalf("GenerateToken 失败: %v", err)
+	}
+
+	c1 := mustParse(t, f, first.AccessToken)
+	c2 := mustParse(t, f, second.AccessToken)
+
+	if c1.ID == "" {
+		t.Fatal("access token 没有 jti")
+	}
+	if c1.ID == c2.ID {
+		t.Fatalf("两次签发的 jti 相同(%s)—— jti 没起到区分作用", c1.ID)
+	}
+}
+
+// 加了 jti 不能破坏原有校验:token 照常验得过,业务字段照常读得出。
+func TestGenerateToken_StillValidatesAndCarriesClaims(t *testing.T) {
+	f := testJWT()
+
+	resp, err := f.GenerateToken(7, "who@example.com", []string{"vip"})
+	if err != nil {
+		t.Fatalf("GenerateToken 失败: %v", err)
+	}
+
+	claims := mustParse(t, f, resp.AccessToken)
+	if claims.UserID != 7 {
+		t.Errorf("UserID = %d, 期望 7", claims.UserID)
+	}
+	if claims.Email != "who@example.com" {
+		t.Errorf("Email = %q, 期望 who@example.com", claims.Email)
+	}
+	if len(claims.Features) != 1 || claims.Features[0] != "vip" {
+		t.Errorf("Features = %v, 期望 [vip]", claims.Features)
+	}
+	if claims.Issuer != "aurora-test" {
+		t.Errorf("Issuer = %q, 期望 aurora-test", claims.Issuer)
+	}
+}
+
+// 老 token(没有 jti)必须继续验得过 —— 加 jti 只是"多写一个字段",不是强制要求它存在。
+// 否则升级的那一刻,所有已签发的 token 会集体失效,把全部在线用户踢下线。
+func TestParse_LegacyTokenWithoutJTI_StillValid(t *testing.T) {
+	f := testJWT()
+
+	// 手工造一个升级前格式的 token:没有 ID(jti)字段
+	now := time.Now()
+	legacy := &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			Issuer:    "aurora-test",
+			Subject:   "9",
+		},
+		UserID: 9,
+		Email:  "legacy@example.com",
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, legacy).SignedString([]byte("test-secret"))
+	if err != nil {
+		t.Fatalf("构造老 token 失败: %v", err)
+	}
+
+	claims := mustParse(t, f, signed)
+	if claims.UserID != 9 {
+		t.Errorf("老 token 解出的 UserID = %d, 期望 9", claims.UserID)
+	}
+	if claims.ID != "" {
+		t.Errorf("老 token 不该有 jti,却解出 %q", claims.ID)
+	}
+}
+
+func mustParse(t *testing.T, f *jwtFeature, token string) *Claims {
+	t.Helper()
+	claims, err := f.parseClaims(token)
+	if err != nil {
+		t.Fatalf("解析 token 失败: %v", err)
+	}
+	return claims
+}


### PR DESCRIPTION
## 问题

同一用户在**同一秒内**签发的两个 token,**字节完全相同**。

`Claims` 里除时间戳外的字段(`issuer` / `subject` / `user_id` / `email` / `features`)对同一用户都是固定的,而 `jwt.NewNumericDate` 默认只精确到**秒**,且没有 `jti` 或任何随机项:

```go
claims := &Claims{
    RegisteredClaims: jwt.RegisteredClaims{
        ExpiresAt: jwt.NewNumericDate(expiresAt),   // 秒
        IssuedAt:  jwt.NewNumericDate(now),         // 秒
        NotBefore: jwt.NewNumericDate(now),         // 秒
        Issuer:    f.Config.Issuer,                 // 固定
        Subject:   fmt.Sprintf("%d", userID),       // 固定
    },
    UserID: userID, Email: email, Features: features,   // 固定
}
```

实测(照抄本函数的 claims 构造,同一秒连签 3 个):

```
A == B ? true
B == C ? true
```

**它们在密码学意义上就是同一个凭据。**

## 为什么这对 aurora 是硬伤

关键不在于"JWT 应不应该带 jti"(见下,那是可选的),而在于 **aurora 已经在做需要 token 身份的事了** —— 它有黑名单:

```go
// ValidateToken / Logout
key := fmt.Sprintf("%s:%s", RedisKeyBlackAccessTokenPrefix, tokenString)
```

`Logout` 按**整个 token 字符串**当 key 拉黑。这个实现**只在 token 唯一时才成立**,而它恰恰不唯一。于是:

1. **登出会误伤**:登出一台设备,同秒登录的另一台也一起掉线。
2. **上层无法区分设备**:业务侧按 `sha256(token)` 做登录设备数限制时,同秒登录的两台设备哈希相同 —— 想踢掉其中一台,另一台必然跟着掉,做不出「只踢最老那台」。
3. **`RefreshToken` 轮换会认错**:按 token 找"当前会话"时,两条记录无法区分。

这不是理论问题:它是在给 homeserver 写「登录设备数上限」的端到端测试时撞出来的 —— 三次登录在几毫秒内完成,必然同秒。

## 修复

access / refresh 的 claims 各加一个 `jti`(`RegisteredClaims.ID`),128 bit `crypto/rand` 随机 + 十六进制。

**不引入新依赖** —— `crypto/rand` 和 `encoding/hex` 都是标准库。用 `crypto/rand` 而非 `math/rand`:token 标识应当不可预测。

## 为什么不是「把时间戳改成毫秒精度」

这是最自然的替代方案,而且**它是 RFC 合规的** —— RFC 7519 §2 明确允许 NumericDate 取非整数值("non-integer values can be represented"),golang-jwt 也支持(`jwt.TimePrecision`)。但三条理由让我没选它:

**一、它把「保证」换成了「概率」。** 毫秒只是把碰撞窗口缩小 1000 倍,**并发登录时该撞还是撞**。用**真实的 `GenerateToken`**(含 HMAC 签名)并发跑 200 次,统计落在同一毫秒的:

```
真实并发签发 200 次(含 HMAC):
  落在同一毫秒的重复: 197 次,最多 181 个挤在同一毫秒
  → 毫秒精度下,这 200 次里会有 197 个 token 与别人字节相同
```

也就是说毫秒精度在并发场景下几乎没有帮助 —— 签一个 token 远快于 1 毫秒,同时到达的请求会齐刷刷落进同一格。

改微秒、纳秒也一样 —— 只是把概率压小,永远不是保证。而"哪个会话被登出/踢下线"是一条安全边界,它的正确性不该取决于两次请求恰好没落在同一个时间刻度里。

**二、`TimePrecision` 是包级全局变量,副作用外溢到整个进程。** 库自己的注释:

```go
// TimePrecision sets the precision of times and dates within this library. This
// has an influence on the precision of times when comparing expiry or other
// related time fields. Furthermore, it is also the precision of times when serializing.
//
// For backwards compatibility the default precision is set to seconds, so that
// no fractional timestamps are generated.
var TimePrecision = time.Second
```

它影响的不只是签发,**还有校验**。aurora 是被多个服务共用的框架,去改第三方库的全局状态,会隐式波及进程里任何别的 JWT 用途。

**三、互操作风险。** 库自己默认避开小数是有原因的 —— 很多 JWT 解析器(网关、客户端库、调试工具)假定 `exp`/`iat` 是整数。**改标准字段的格式,比新增一个标准可选字段风险大。**

代价对比:

| | 毫秒精度 | jti |
|---|---|---|
| 唯一性 | 概率(并发仍撞) | 保证(128 bit 随机) |
| 副作用 | 改第三方库全局状态,影响全进程(含校验) | 无 |
| 互操作 | 标准字段变小数,解析器可能不认 | 标准可选字段,不认就忽略 |
| token 体积 | 不变 | **+54 字节**(实测 271 → 325 字节) |
| 老 token 兼容 | 兼容 | 兼容(只写不验) |

## 关于「jti 是不是必备」—— 不是,但这里需要

说清楚免得误解:**RFC 7519 §4.1.7 明确写着 "Use of this claim is OPTIONAL"**。大量 JWT 系统不带 `jti`,而且完全正确 —— 因为它们是**无状态**的:签发后不再追踪单个 token,自然不需要给 token 一个身份。

但一旦要做撤销/登出/踢下线,就必须能指认某一个具体 token,这时 `jti` 就是标准机制。RFC 对它的要求正是这个:

> The "jti" (JWT ID) claim provides a unique identifier for the JWT. The identifier value **MUST be assigned in a manner that ensures that there is a negligible probability that the same value will be accidentally assigned** to a different data object. ... The "jti" claim can be used to prevent the JWT from being replayed.

**aurora 已经踏进了「有状态撤销」这条路(它有黑名单),却没有那条路必需的这块砖。** 这才是加 jti 的理由 —— 不是"行业都这么干"。

## 兼容性:老 token 不受影响

只**写入** `jti`,**不校验它是否存在**。升级前签发的 token(没有 `jti`)继续验得过 —— 否则升级的那一刻,所有已签发 token 会集体失效,把全部在线用户踢下线。已有测试覆盖(`TestParse_LegacyTokenWithoutJTI_StillValid`)。

## 测试

`feature` 包此前**没有任何测试** —— 这正是这个问题能一直存在的原因。本次补上:

| 测试 | 验什么 |
|---|---|
| `TestGenerateToken_SameSecondTokensAreUnique` | 同一秒连签 20 个,access/refresh 均两两不同 |
| `TestGenerateToken_AccessAndRefreshDiffer` | access 与 refresh 不相同 |
| `TestGenerateToken_HasUniqueJTI` | jti 存在,且两次签发不同 |
| `TestGenerateToken_StillValidatesAndCarriesClaims` | 加 jti 后校验与业务字段读取不受影响 |
| `TestParse_LegacyTokenWithoutJTI_StillValid` | 老格式 token(无 jti)仍然有效 |

**已反向验证测试不是安慰剂**:把 `ID: tokenID` 摘掉(保持编译通过)后重跑,测试立刻变红并报出原始症状:

```
--- FAIL: TestGenerateToken_SameSecondTokensAreUnique
    第 2 次签发的 access token 与之前某个完全相同 —— 同一秒登录的两台设备会共用一个凭据,登出/踢下线时会互相牵连
--- FAIL: TestGenerateToken_HasUniqueJTI
    access token 没有 jti
```

加回来即恢复全绿。`go test ./...` 与 `go vet ./...` 全通过。

## 后续可做(不在本 PR)

行业通行做法是**用 jti 当黑名单 key**(32 字符),而不是整个 token 字符串(325 字节)。aurora 现在是后者。有了 jti 之后这个优化就可行了,但那是独立的改动,不该混进来。

## 参考

- [RFC 7519 §4.1.7 — the "jti" claim](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7)(jti 定义与 OPTIONAL 声明)
- [RFC 7519 §2 — NumericDate](https://datatracker.ietf.org/doc/html/rfc7519#section-2)(允许非整数值 —— 即毫秒方案合规)
- [Understanding JWT Revocation Strategies: Allowlist, Denylist, and JTI Matcher](https://medium.com/@ahmedosamaft/understanding-jwt-revocation-strategies-allowlist-denylist-and-jti-matcher-9d298893f8a1)
- [How to Build a Token Blacklist for JWT Revocation with Redis](https://oneuptime.com/blog/post/2026-03-31-redis-how-to-build-a-token-blacklist-for-jwt-revocation-with-redis/view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

