### PR TITLE
feat(db): 支持可选的连接寿命 / 空闲寿命配置

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -1,12 +1,26 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type DatabaseConfig struct {
 	Driver       string `env:"DB_DRIVER"`
 	DSN          string `env:"DB_DSN"`
 	MaxIdleConns int    `env:"DB_MAX_IDLE_CONNS"`
 	MaxOpenConns int    `env:"DB_MAX_OPEN_CONNS"`
+
+	// ConnMaxLifetime 单条连接从建立起最长可复用时长。0(不设)= 永不因年龄回收
+	// (database/sql 默认,保持旧行为,向后兼容)。设为正值时连接池定期回收连接,
+	// 主要作用是避开「MySQL wait_timeout 服务端关掉空闲连接后、连接池仍握着已失效连接」
+	// 导致的偶发 invalid connection。建议设为小于 DB 的 wait_timeout(如 1h)。
+	ConnMaxLifetime time.Duration `env:"DB_CONN_MAX_LIFETIME,omitempty"`
+
+	// ConnMaxIdleTime 空闲连接最长保留时长。0(不设)= 空闲连接不因空闲时长被关,仅受
+	// MaxIdleConns 条数上限约束(保持旧行为)。设为正值时,闲置超过该时长的连接被关,
+	// 低峰期把空闲池缩到 MaxIdleConns 以下,进一步降低对 DB 的常驻连接占用。
+	ConnMaxIdleTime time.Duration `env:"DB_CONN_MAX_IDLE_TIME,omitempty"`
 }
 
 func (s *DatabaseConfig) Key() string {
@@ -35,6 +49,14 @@ func (s *DatabaseConfig) Validate() error {
 
 	if s.MaxIdleConns > s.MaxOpenConns {
 		return NewConfigError("DB_MAX_IDLE_CONNS must be less than or equal to DB_MAX_OPEN_CONNS")
+	}
+
+	// 二者可选(omitempty),但给了就不能是负值。0 = 不设,保持旧行为。
+	if s.ConnMaxLifetime < 0 {
+		return NewConfigError("DB_CONN_MAX_LIFETIME must not be negative")
+	}
+	if s.ConnMaxIdleTime < 0 {
+		return NewConfigError("DB_CONN_MAX_IDLE_TIME must not be negative")
 	}
 
 	supportedDrivers := []string{"mysql", "sqlite", "postgres", "postgresql", "pgx"}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -457,3 +457,74 @@ func TestResolveConfig_RealWorldExampleRedis(t *testing.T) {
 		t.Errorf("DB = %v, want 1", cfg.DB)
 	}
 }
+
+// TestDatabaseConfig_ConnMaxDurations 验证新增的连接寿命/空闲寿命字段:
+//   - 显式设置能按 duration 解析;
+//   - 不设(omitempty)= 0,保持旧行为(向后兼容);
+//   - 负值被 Validate 拒绝。
+func TestDatabaseConfig_ConnMaxDurations(t *testing.T) {
+	base := func() {
+		os.Setenv("DB_DRIVER", "mysql")
+		os.Setenv("DB_DSN", "user:pass@tcp(localhost:3306)/db")
+		os.Setenv("DB_MAX_IDLE_CONNS", "10")
+		os.Setenv("DB_MAX_OPEN_CONNS", "50")
+	}
+	cleanup := func() {
+		for _, k := range []string{"DB_DRIVER", "DB_DSN", "DB_MAX_IDLE_CONNS", "DB_MAX_OPEN_CONNS", "DB_CONN_MAX_LIFETIME", "DB_CONN_MAX_IDLE_TIME"} {
+			os.Unsetenv(k)
+		}
+	}
+
+	// 1) 显式设置 → 正确解析
+	t.Run("set", func(t *testing.T) {
+		defer cleanup()
+		base()
+		os.Setenv("DB_CONN_MAX_LIFETIME", "1h")
+		os.Setenv("DB_CONN_MAX_IDLE_TIME", "30m")
+
+		cfg := &DatabaseConfig{}
+		if err := ResolveConfig(cfg); err != nil {
+			t.Fatalf("ResolveConfig failed: %v", err)
+		}
+		if cfg.ConnMaxLifetime != time.Hour {
+			t.Errorf("ConnMaxLifetime = %v, want 1h", cfg.ConnMaxLifetime)
+		}
+		if cfg.ConnMaxIdleTime != 30*time.Minute {
+			t.Errorf("ConnMaxIdleTime = %v, want 30m", cfg.ConnMaxIdleTime)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error: %v", err)
+		}
+	})
+
+	// 2) 不设 → 0(向后兼容),且 Validate 通过
+	t.Run("unset_backward_compatible", func(t *testing.T) {
+		defer cleanup()
+		base()
+
+		cfg := &DatabaseConfig{}
+		if err := ResolveConfig(cfg); err != nil {
+			t.Fatalf("ResolveConfig failed: %v", err)
+		}
+		if cfg.ConnMaxLifetime != 0 {
+			t.Errorf("ConnMaxLifetime = %v, want 0 (unset)", cfg.ConnMaxLifetime)
+		}
+		if cfg.ConnMaxIdleTime != 0 {
+			t.Errorf("ConnMaxIdleTime = %v, want 0 (unset)", cfg.ConnMaxIdleTime)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() with unset durations should pass, got: %v", err)
+		}
+	})
+
+	// 3) 负值 → Validate 报错
+	t.Run("negative_rejected", func(t *testing.T) {
+		cfg := &DatabaseConfig{
+			Driver: "mysql", DSN: "x", MaxIdleConns: 1, MaxOpenConns: 1,
+			ConnMaxLifetime: -1,
+		}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() should reject negative ConnMaxLifetime")
+		}
+	})
+}

--- a/feature/gorm.go
+++ b/feature/gorm.go
@@ -91,6 +91,13 @@ func (f *gormFeature) provideDatabase() (*gorm.DB, *sql.DB, error) {
 
 	sqlDB.SetMaxIdleConns(f.config.MaxIdleConns)
 	sqlDB.SetMaxOpenConns(f.config.MaxOpenConns)
+	// 0 = 不设,保持 database/sql 默认(连接不因年龄/空闲时长回收),向后兼容。
+	if f.config.ConnMaxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(f.config.ConnMaxLifetime)
+	}
+	if f.config.ConnMaxIdleTime > 0 {
+		sqlDB.SetConnMaxIdleTime(f.config.ConnMaxIdleTime)
+	}
 
 	if err := sqlDB.Ping(); err != nil {
 		log.Fatalf("Failed to ping %s database: %v", f.config.Driver, err)


### PR DESCRIPTION
## 背景

`DatabaseConfig` 之前只暴露 `MaxIdleConns` / `MaxOpenConns`,[feature/gorm.go](feature/gorm.go) 也只调了 `SetMaxIdleConns` / `SetMaxOpenConns` —— **想设 `ConnMaxLifetime` 都没有入口**。这会导致长时间空闲的连接被 MySQL `wait_timeout` 服务端关掉后,连接池仍握着已失效连接,偶发 `invalid connection`(低峰服务尤其明显)。

## 改动

给 `DatabaseConfig` 加两个**可选**字段:

| env | 字段 | 作用 |
|---|---|---|
| `DB_CONN_MAX_LIFETIME` | `ConnMaxLifetime` | 单连接最长可复用时长,到点回收(建议 < DB `wait_timeout`,如 `1h`) |
| `DB_CONN_MAX_IDLE_TIME` | `ConnMaxIdleTime` | 空闲连接最长保留时长,低峰期把空闲池缩到 `MaxIdleConns` 以下、释放连接给 DB 腾余量 |

gorm feature 仅在值 `> 0` 时才调用对应 setter。

## 向后兼容

- 两字段都标 `,omitempty`,**不设 = 0 = 保持 `database/sql` 默认行为**(连接不因年龄/空闲时长回收)。
- 现有所有 aurora 用户不设这俩 env → 行为与现在**完全一致**,零破坏。
- `Validate` 拒绝负值。

## 测试

新增 `TestDatabaseConfig_ConnMaxDurations` 3 个子测试:显式解析 / 向后兼容(不设=0)/ 拒负值。`go build` `go test` `go vet` 全通过。