### PR TITLE
docs: 新增框架文档体系(架构 + 各 feature)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,43 @@
+# Aurora 框架文档
+
+Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 邮件 + 迁移」收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、按环境变量配置、统一启停。
+
+> 快速上手和完整示例见仓库根 [README.md](../README.md) 与 [sample/](../sample/)。本目录是**成体系的深度文档**:讲清每个机制的真实行为和坑。
+
+## 核心
+
+- **[架构与核心机制](./architecture.md)** —— App 生命周期、Feature 系统、依赖注入、启停时序。**先读这篇。**
+- **[配置系统 ResolveConfig](./features/config.md)** —— env tag / omitempty / Validate;⚠️ 含 `envDefault` 无效等致命坑。
+
+## Features
+
+| 文档 | 内容 | 关键点 |
+|---|---|---|
+| [server](./features/server.md) | HTTP 服务器、路由、Handler 约定、健康检查、优雅停机 | Handler 返回 `(data, BizError)`;`SHUTDOWN_TIMEOUT` |
+| [gorm](./features/gorm.md) | 数据库、连接池 | 多服务共库要算连接总账;`ConnMaxLifetime/IdleTime` |
+| [redis](./features/redis.md) | Redis 封装、分布式锁 | `WithLock` 是 skip-if-running;`REDIS_PASSWORD` 强制非空 |
+| [jwt](./features/jwt.md) | access/refresh token、黑名单登出 | jti;黑名单 TTL=剩余寿命;Redis 故障 fail-open |
+| [i18n](./features/i18n.md) | 多语言翻译 | 请求语言:`?lang=`>Accept-Language;`LoadEmbedded` 未用 |
+| [mail](./features/mail.md) | SMTP 发信 | MAIL_* 全强制必填,不发信也要填占位 |
+| [migration](./features/migration.md) | goose 迁移 | `GOOSE_TABLE_PREFIX` 隔离共库版本表;worker 别跑迁移 |
+| [错误模型 & 日志](./features/bizerr.md) | bizerr / logger | 默认响应只含 message;LOG_LEVEL>RUN_LEVEL |
+
+## 贯穿全框架的几个"坑"(务必知道)
+
+这些是文档里反复出现、最容易踩的点,集中列一下:
+
+1. **`envDefault` 是死标签** —— `ResolveConfig` 不读它。`ServerConfig` 里那些 `envDefault` 全不生效,且字段无 `omitempty` = **实际必填**。要默认值靠代码,不靠 tag。见 [config.md](./features/config.md)。
+2. **`omitempty` 决定必填性** —— 无 `omitempty` 的字段缺 env 就启动失败。可选字段务必加。
+3. **`Validate` 要手动调** —— `ResolveConfig` 不自动校验。
+4. **`REDIS_PASSWORD` 强制非空** —— 无密码 Redis 也得填占位(如 `none`)。
+5. **优雅停机只关 HTTP** —— 不自动关其它 feature、不排空后台任务(asynq 等)。后台排空要在 `main` 里自己编排。见 [server.md](./features/server.md) 和 [architecture.md](./architecture.md)。
+6. **默认错误响应只有 `message`** —— 字段级校验明细要自定义 ErrorHandler。见 [bizerr.md](./features/bizerr.md)。
+
+## 已知待改进项(文档暴露的框架缺口)
+
+写文档过程中发现的、值得后续修的框架问题(非阻塞,记录在案):
+
+- `config/server.go` 的 `envDefault` 标签是死代码,建议要么让 `ResolveConfig` 真正支持 `envDefault`,要么删掉这些误导标签并给字段加 `omitempty` + 代码默认值。
+- `i18n` 的 `LoadEmbedded`(`I18N_LOAD_EMBEDDED`)声明了但从未被读取,要么接上要么删。
+- `mail` 全字段强制必填,不利于"可选发信"场景,可考虑改 `omitempty` + 用时判空。
+- `RedisService` 未设 `PoolSize`,高并发下走默认池(`10×GOMAXPROCS`),可考虑做成可配。

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,256 @@
+# Aurora 架构与核心机制
+
+> 本文讲 Aurora 的"骨架"——App 生命周期、Feature 系统、依赖注入、配置解析。
+> 各 Feature 的具体用法见 [features/](./features/)。
+
+Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 邮件 + 迁移」这些每个服务都要重写的基础设施,收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、统一按环境变量配置、统一启停。
+
+---
+
+## 1. 三个核心抽象
+
+| 抽象 | 定义位置 | 职责 |
+|---|---|---|
+| **App** | [contracts/app.go](../contracts/app.go) | 容器 + 生命周期。装 Feature、注册路由、Run/Shutdown。内嵌 `di.Container`,本身就是 DI 容器。 |
+| **Feature** | [contracts/feature.go](../contracts/feature.go) | 一个可插拔的基础设施单元(gorm/redis/jwt…)。三个方法:`Name() / Setup(app) / Close()`。 |
+| **Config** | [config/](../config/) | 每个 Feature 的配置结构体,字段用 `env:"XXX"` tag 声明,由 `ResolveConfig` 从环境变量填充。 |
+
+Feature 接口极简([contracts/feature.go](../contracts/feature.go)):
+
+```go
+type Features interface {
+    Name() string        // feature 名(日志/错误用)
+    Setup(app App) error // 初始化:建连接、Provide 依赖到容器、注册路由
+    Close() error        // 释放:关连接
+}
+```
+
+**任何实现了这三个方法的类型都能作为 Feature 挂进 App** —— 这是框架的扩展点(见 [§5 自定义 Feature](#5-写一个自定义-feature))。
+
+---
+
+## 2. App 生命周期
+
+一个典型 `main` 就三行:
+
+```go
+func main() {
+    app := bootstrap.InitDefaultApp()          // 1. 装配
+    app.RegisterRoutes(controller.GetRoutes(app)) // 2. 注册业务路由
+    app.Run()                                   // 3. 启动,阻塞到退出信号
+}
+```
+
+### 2.1 装配阶段 —— `InitDefaultApp`
+
+[bootstrap/default.go](../bootstrap/default.go) 定义了"默认全家桶",**注册顺序即依赖顺序**:
+
+```go
+func InitDefaultApp() contracts.App {
+    a := app.NewApp()                    // 建容器,解析 ServerConfig,注册基础依赖
+
+    server := feature.NewServerFeature() // ★ server 必须最先
+    a.AddFeature(server)
+
+    a.AddFeature(feature.NewGormFeature())  // DB
+    a.AddFeature(feature.NewRedisFeature()) // Redis
+    a.AddFeature(feature.NewJWTFeature())   // JWT(依赖 Redis 做黑名单)
+    a.AddFeature(feature.NewI18NFeature())  // i18n
+    a.AddFeature(feature.NewMailFeature())  // 邮件
+
+    migration.RunMigrations(a)           // ★ 最后跑 DB 迁移
+    return a
+}
+```
+
+> **为什么 server 最先**:`AddFeature` 里对 `ServerFeature` 做了特殊处理(见下),后续 feature 若要注册路由需要 server 已就位。
+> **为什么迁移最后**:迁移要用已建好的 `*gorm.DB`。
+
+如果默认全家桶不合适(比如 worker 进程不想跑迁移),就**不要用 `InitDefaultApp`**,自己 `app.NewApp()` 再手动 `AddFeature` 想要的子集。homeserver 的 `wire.InitWorkerApp()` 就是这么做的(worker 不跑迁移,避免和 API 并发抢 goose)。
+
+### 2.2 `NewApp` 做了什么
+
+[app/app.go:24](../app/app.go#L24):
+
+1. `ResolveConfig(&cfg.Server)` —— 解析 `ServerConfig`(端口、名字、超时等),失败直接 `log.Fatalf`。
+2. `di.NewContainer()` —— 建依赖注入容器。
+3. `registerBaseDependencies()` —— 把 `ServerConfig` 自身 Provide 进容器,供后续 feature 取用。
+
+### 2.3 `AddFeature` 做了什么
+
+[app/app.go:54](../app/app.go#L54):
+
+```go
+func (a *app) AddFeature(f contracts.Features) {
+    if server, ok := f.(contracts.ServerFeature); ok {
+        a.serverFeature = server   // ★ 若是 ServerFeature,单独记住(Run 时用)
+    }
+    if err := f.Setup(a); err != nil {
+        log.Fatalf("Failed to setup feature %s: %v", f.Name(), err)  // Setup 失败 = 进程退出
+    }
+    a.features = append(a.features, f) // 记录以便反序 Close
+}
+```
+
+关键点:
+- **Setup 立即执行**,不是延迟到 Run。所以 `AddFeature` 的调用顺序 = 初始化顺序。
+- **Setup 失败 = `log.Fatalf` 直接终止进程**。这是框架的"fail-fast"原则:配置缺失/连不上 DB 就别启动。
+- feature 按加入顺序存进 `a.features`,**Shutdown 时反序 Close**。
+
+### 2.4 运行阶段 —— `Run`
+
+[app/app.go:74](../app/app.go#L74):
+
+```go
+func (a *app) Run() error {
+    a.printStartupInfo()             // 打印 banner(服务名/版本/地址/RunLevel)
+    a.serverFeature.Start()          // 起 HTTP server(非阻塞,内部 goroutine)
+    a.serverFeature.Wait()           // ★ 阻塞在这里,直到 server 退出
+    return nil
+}
+```
+
+`Run` 会一直阻塞在 `serverFeature.Wait()`,直到 server feature 收到退出信号并完成关停。**优雅停机的逻辑在 server feature 内部**(监听 SIGINT/SIGTERM → `http.Server.Shutdown(ctx)`),详见 [features/server.md](./features/server.md)。
+
+### 2.5 关停 —— `Shutdown`
+
+[app/app.go:85](../app/app.go#L85) 提供了**反序**关闭所有 feature 的 `Shutdown()`:
+
+```go
+func (a *app) Shutdown() error {
+    for i := len(a.features) - 1; i >= 0; i-- { // 后进先出
+        a.features[i].Close()
+    }
+    return nil
+}
+```
+
+> ⚠️ **注意**:`Run()` 内部**并不会自动调用 `a.Shutdown()`**。server feature 收到信号只关 HTTP server,然后 `Run` 返回、`main` 结束、进程退出;gorm/redis 的 `Close()` 靠进程退出由 OS 兜底,而非显式调用。若你需要在退出前显式排空后台任务(如 asynq worker),要在 `main` 里自己编排 —— 参见 homeserver worker 的 `defer scheduleWorker.Stop()` 模式。
+
+---
+
+## 3. Feature 启停时序图
+
+```
+main
+ │
+ ├─ bootstrap.InitDefaultApp()
+ │    ├─ app.NewApp() ──────────── ResolveConfig(Server) → DI 容器 → Provide(ServerConfig)
+ │    ├─ AddFeature(server) ─────── server.Setup(app)   [建 gin engine]
+ │    ├─ AddFeature(gorm) ───────── gorm.Setup(app)     [连 DB, Provide *gorm.DB / *sql.DB]
+ │    ├─ AddFeature(redis) ──────── redis.Setup(app)    [连 Redis, Provide RedisService]
+ │    ├─ AddFeature(jwt) ────────── jwt.Setup(app)      [取 RedisService, Provide JWT]
+ │    ├─ AddFeature(i18n) ───────── i18n.Setup(app)     [加载 locale]
+ │    ├─ AddFeature(mail) ───────── mail.Setup(app)     [校验 SMTP 配置]
+ │    └─ RunMigrations(app) ─────── [用 *gorm.DB 跑 goose]
+ │
+ ├─ app.RegisterRoutes(routes) ──── serverFeature.RegisterRoutes()
+ │
+ └─ app.Run()
+      ├─ serverFeature.Start() ──── ListenAndServe (goroutine) + signalListener (goroutine)
+      └─ serverFeature.Wait() ───── 阻塞…
+             │
+        [SIGTERM]
+             │
+        server.Shutdown(ctx) ────── 排空在途请求(超时 SHUTDOWN_TIMEOUT)
+             │
+        Wait() 返回 → Run() 返回 → main 结束
+```
+
+---
+
+## 4. 依赖注入(DI)
+
+App 内嵌了 `github.com/shyandsy/di` 的 `Container`([contracts/app.go:17](../contracts/app.go#L17)),所以 **App 本身就是 DI 容器**,可直接调用容器方法。
+
+### 4.1 两种角色
+
+- **Feature 是"生产者"**:在 `Setup(app)` 里把自己建好的对象 `app.Provide(x)` 放进容器。
+  例:gorm feature Provide 了 `*gorm.DB` 和 `*sql.DB`;redis feature Provide 了 `RedisService`。
+- **业务代码是"消费者"**:用 `app.Find(&x)` 或结构体字段 `inject:""` tag 取出依赖。
+
+### 4.2 消费依赖的两种写法
+
+```go
+// 写法 A:显式 Find
+var db *gorm.DB
+app.Find(&db)
+
+// 写法 B:结构体 inject tag(推荐给 service/datalayer)
+type customerService struct {
+    DB    *gorm.DB              `inject:""`
+    Redis feature.RedisService  `inject:""`
+}
+// app.Resolve(&svc) 会自动填充所有 inject:"" 字段
+```
+
+homeserver 里 `wire.RegisterProviders` + `app.Resolve` 就是批量装配 service/datalayer 依赖图的入口。
+
+---
+
+## 5. 写一个自定义 Feature
+
+任何服务专属的基础设施(对象存储、消息队列消费者、指标上报…)都可以做成 Feature 挂进来。三步:
+
+```go
+package feature
+
+type ossFeature struct {
+    config *OSSConfig
+    client *oss.Client
+}
+
+// 1. 实现 Features 接口
+func (f *ossFeature) Name() string { return "oss" }
+
+func (f *ossFeature) Setup(app contracts.App) error {
+    if err := f.config.Validate(); err != nil {
+        return err                       // 返回 error → App 会 Fatalf,fail-fast
+    }
+    f.client = oss.New(f.config.Endpoint, ...)
+    app.Provide(f.client)                // 2. 把产物 Provide 进容器供业务用
+    return nil
+}
+
+func (f *ossFeature) Close() error {
+    return f.client.Close()              // 3. 释放
+}
+
+// 挂进去(替代 InitDefaultApp 或在其后 AddFeature)
+app.AddFeature(NewOSSFeature())
+```
+
+配套的 `OSSConfig` 按 [配置系统](#6-配置系统) 的约定写 `env` tag 即可。
+
+---
+
+## 6. 配置系统
+
+所有 Feature 配置统一走 `config.ResolveConfig(&cfg)`([config/resolve.go](../config/resolve.go)),从**环境变量**填充带 `env` tag 的字段。核心约定见 [features/config.md](./features/config.md),这里只记要点:
+
+- 字段用 `env:"XXX"` 声明来源环境变量;
+- **缺值 = 报错**(fail-fast),除非标 `,omitempty` → 缺值时跳过(保持零值);
+- 支持 `string / int / bool / time.Duration` 等类型(duration 走 `time.ParseDuration`,如 `"30s"` `"1h"`);
+- 每个 config 结构体实现 `Key()` 和 `Validate()`;`Validate` 在 feature `Setup` 里被调用做业务校验。
+
+**给配置加字段的正确姿势**(以本仓刚加的连接寿命为例,[config/database.go](../config/database.go)):
+
+```go
+type DatabaseConfig struct {
+    // 必填:缺 env 直接报错
+    MaxOpenConns    int           `env:"DB_MAX_OPEN_CONNS"`
+    // 可选:不设 = 零值 = 保持旧行为,向后兼容
+    ConnMaxLifetime time.Duration `env:"DB_CONN_MAX_LIFETIME,omitempty"`
+}
+```
+
+> ⚠️ **常见坑**:`ResolveConfig` **只认 `env` tag,不读 `envDefault`**。想要默认值,要么在构造 config 的地方写结构体字面量默认值,要么在 `Validate` 里兜底 —— 不要指望 `envDefault:"xxx"` 生效。
+
+---
+
+## 7. 相关文档
+
+- 各 Feature 详解 → [features/](./features/)
+- 配置解析机制详解 → [features/config.md](./features/config.md)
+- 错误模型 → [features/bizerr.md](./features/bizerr.md)
+- 快速开始 / 完整示例 → 仓库根 [README.md](../README.md) 与 [sample/](../sample/)

--- a/doc/features/bizerr.md
+++ b/doc/features/bizerr.md
@@ -1,0 +1,100 @@
+# 错误模型(bizerr)与日志(logger)
+
+## 一、bizerr —— 业务错误
+
+Handler 返回 `(interface{}, bizerr.BizError)`,框架据此写出 HTTP 响应。业务里不要自己 `c.JSON` 写错误,而是 `return nil, bizerr.Xxx()`。
+
+源码:[bizerr/bizerr.go](../../bizerr/bizerr.go)
+
+### BizError 接口
+
+[bizerr/bizerr.go:25](../../bizerr/bizerr.go#L25):
+
+```go
+type BizError interface {
+    HTTPCode() int
+    Message() string
+    Error() string
+    ValidationErrors() map[string]string
+    IsValidationError() bool
+}
+```
+
+> message 来自内部持有的 `err.Error()`,没有独立 message 字段。
+
+### 构造函数
+
+| 构造 | HTTP | 说明 |
+|---|---|---|
+| `New(httpCode, err)` | 自定义 | 通用底层构造 |
+| `ErrBadRequest(err)` | 400 | 变量(函数值),收 error |
+| `ErrInternalServerError(err)` | 500 | 变量,收 error |
+| `ErrUnauthorized()` | 401 | 无参,固定 msg `please login you account` |
+| `ErrForbidden()` | 403 | 无参,固定 msg `http forbidden` |
+| `ErrNotFound()` | 404 | 无参,固定 msg `404 Not Found` |
+| `NewValidationError(msg, fields)` | 400 | 带字段级错误 map |
+| `NewSingleFieldError(field, msg)` | 400 | 单字段校验错误 |
+| `NewMultipleFieldErrors(fields)` | 400 | 多字段校验错误 |
+
+> 都是这几个,**没有** `ErrConflict` / `ErrTooManyRequests` 等;需要就用 `New(409, err)`。注意 `ErrBadRequest` / `ErrInternalServerError` 是**包级变量(函数值)**,调用是 `bizerr.ErrInternalServerError(err)`。
+
+### 用法
+
+```go
+func Handler(c *contracts.RequestContext) (interface{}, bizerr.BizError) {
+    if bad { return nil, bizerr.ErrBadRequest(errors.New("invalid param")) }
+    dto, err := svc.Do(...)
+    if err != nil { return nil, bizerr.ErrInternalServerError(err) }
+    return dto, nil
+}
+```
+
+### 默认响应格式 & 校验错误的坑
+
+默认 handler([feature/server.go:313](../../feature/server.go#L313)):
+
+```json
+{ "message": "<Message()>" }    // 状态码 = HTTPCode()
+```
+
+> ⚠️ **默认只输出 `message`,不输出 `ValidationErrors()` 字段明细**。要把字段级校验错误返回给前端,得用 `WithErrorHandler` 传自定义 `ErrorHandler` 读 `ValidationErrors()` 自己拼(见 [sample/customize_error_handler](../../sample/customize_error_handler))。
+
+### 与 i18n 的关系
+
+**bizerr 不感知语言**,只存原始英文串。翻译在业务层做:**先翻译成串、再塞进 bizerr**:
+
+```go
+msg := c.T("error.customer.not_found")     // i18n 翻译
+return nil, bizerr.NewValidationError(msg, nil)
+```
+
+---
+
+## 二、logger
+
+源码:[logger/logger.go](../../logger/logger.go)
+
+### 方法
+
+```go
+logger.Debug(format, args...) / logger.Debugf(...)   // 同义
+logger.Info(format, args...)  / logger.Infof(...)
+logger.Error(format, args...) / logger.Errorf(...)
+```
+
+- 级别 `Debug(0) < Info(1) < Error(2)`;
+- `Error` **总是输出**;`Info`/`Debug` 按当前级别过滤;
+- error→stderr,info/debug→stdout,均带文件行号。
+
+### 级别怎么定(优先级)
+
+[logger/logger.go:33](../../logger/logger.go#L33) `init()`:
+
+1. **`LOG_LEVEL` 最高优先**:设了就用它(`debug`/`info`/`error`,不分大小写),忽略 RUN_LEVEL;
+2. 否则看 **`RUN_LEVEL`**:
+   - `local` → Debug
+   - `eng` / `stage` → Info
+   - `production` → Error
+   - 未设 / 非法 → **默认 Error**(生产安全)。
+
+也可运行时 `logger.SetLogLevel(...)` / `SetLogLevelFromString(...)` 手动改。

--- a/doc/features/config.md
+++ b/doc/features/config.md
@@ -1,0 +1,109 @@
+# 配置系统(ResolveConfig)
+
+Aurora 所有配置都是「结构体 + `env` tag + `ResolveConfig` 从环境变量填充」。这是框架的核心机制之一,理解它才能正确加配置、避开几个致命坑。
+
+源码:[config/resolve.go](../../config/resolve.go)、[config/error.go](../../config/error.go)
+
+---
+
+## 基本用法
+
+```go
+type MyConfig struct {
+    APIKey  string        `env:"MY_API_KEY"`            // 必填
+    Region  string        `env:"MY_REGION,omitempty"`   // 可选
+    Timeout time.Duration `env:"MY_TIMEOUT,omitempty"`  // duration
+    Hosts   []string      `env:"MY_HOSTS,omitempty"`    // 逗号分隔列表
+}
+
+cfg := &MyConfig{}
+if err := config.ResolveConfig(cfg); err != nil { log.Fatal(err) }
+if err := cfg.Validate(); err != nil { log.Fatal(err) }   // Validate 要自己调!
+```
+
+## `omitempty` 语义(必须理解)
+
+[config/resolve.go:41](../../config/resolve.go#L41):环境变量取到**空串**时:
+
+| tag | 行为 |
+|---|---|
+| `env:"X"`(无 omitempty) | **直接报 required 错误**,进程起不来 |
+| `env:"X,omitempty"` | 跳过,字段保持 Go 零值 |
+
+所以规则很简单:**可选字段必须加 `,omitempty`,否则缺值即启动失败**。
+
+## ⚠️ 致命坑:`envDefault` 完全无效
+
+`ResolveConfig` **只读 `env` tag,从不读 `envDefault`**([config/resolve.go:32](../../config/resolve.go#L32) 只调 `Tag.Get("env")`)。
+
+但 [config/server.go:27](../../config/server.go#L27) 的 `ServerConfig` 却写了一堆 `envDefault:"..."`(`HOST` `envDefault:"0.0.0.0"` 等),**这些标签运行时一律不生效**,纯误导。更糟的是这些字段**没有 `omitempty`** → 它们实际上是**必填**,不设对应 env 直接报错。
+
+**要默认值的正确做法**(二选一):
+
+```go
+// 做法 A:构造 config 时用结构体字面量预填默认值(推荐)
+cfg := &MyConfig{ Timeout: 30 * time.Second }
+config.ResolveConfig(cfg)   // env 有值则覆盖,没值则保留默认
+
+// 做法 B:Validate 里兜底
+func (c *MyConfig) Validate() error {
+    if c.Timeout == 0 { c.Timeout = 30 * time.Second }
+    return nil
+}
+```
+
+**永远不要用 `envDefault`**,它是死标签。
+
+## 支持的字段类型
+
+[config/resolve.go:57](../../config/resolve.go#L57) `setFieldValue`:
+
+| 类型 | 说明 |
+|---|---|
+| `string` | 直接赋值 |
+| `int` 系列 | `strconv.ParseInt` + 溢出检查 |
+| `time.Duration` | `time.ParseDuration`,值写 `"30s"` `"1h"` `"720h"` |
+| `uint` / `float` 系列 | 对应 Parse + 溢出检查 |
+| `bool` | `strconv.ParseBool`(`1/t/true/0/f/false`…) |
+| `[]string` | 按 `,` 分割、逐段 TrimSpace、丢空段 |
+| 其它 slice(如 `[]int`) | **不支持**,报错 |
+| 其它类型 | **不支持**,报错 |
+
+## config 结构体的隐式契约
+
+每个 config 结构体约定实现两个方法:
+
+- `Key() string` —— 稳定标识(`"server"` / `"redis"` / …),供按 key 注册查找。
+- `Validate() error` —— 业务校验,返回 `*ConfigError`([config/error.go](../../config/error.go),`NewConfigError(msg)`)。
+
+> ⚠️ **`ResolveConfig` 不会自动调 `Validate`**。固定模式是:`ResolveConfig(cfg)` → `cfg.Validate()`,两步都要自己写。框架各 feature 的 `Setup` 里就是这么做的(如 [feature/gorm.go:36](../../feature/gorm.go#L36))。
+
+## 加自定义配置的完整范例
+
+```go
+package config
+
+import "time"
+
+type OSSConfig struct {
+    Provider  string `env:"OSS_PROVIDER,omitempty"`   // 可选,空 = 关闭 OSS
+    Endpoint  string `env:"OSS_ENDPOINT,omitempty"`
+    Bucket    string `env:"OSS_BUCKET,omitempty"`
+    KeyID     string `env:"OSS_ACCESS_KEY_ID,omitempty"`
+    KeySecret string `env:"OSS_ACCESS_KEY_SECRET,omitempty"`
+}
+
+func (c *OSSConfig) Key() string { return "oss" }
+
+func (c *OSSConfig) Validate() error {
+    if c.Provider == "" {
+        return nil   // 未配 = 功能关闭,不报错
+    }
+    if c.Endpoint == "" || c.Bucket == "" {
+        return NewConfigError("OSS_ENDPOINT and OSS_BUCKET are required when OSS_PROVIDER is set")
+    }
+    return nil
+}
+```
+
+三个要点:① 可选字段全加 `omitempty`;② 要默认值靠代码不靠 envDefault;③ `Validate` 自己实现、由 feature 的 `Setup` 显式调用。

--- a/doc/features/gorm.md
+++ b/doc/features/gorm.md
@@ -1,0 +1,82 @@
+# Gorm Feature(数据库)
+
+封装 GORM,负责建连接、配连接池、把 `*gorm.DB` 和 `*sql.DB` 注入 DI 容器。
+
+源码:[feature/gorm.go](../../feature/gorm.go)、[config/database.go](../../config/database.go)
+
+---
+
+## 创建 & 用法
+
+```go
+app.AddFeature(feature.NewGormFeature())
+```
+
+`Setup` 后,容器里有两个可注入对象([feature/gorm.go:47](../../feature/gorm.go#L47)):
+
+```go
+type customerDatalayer struct {
+    DB *gorm.DB `inject:""`   // ORM,业务查询用这个
+}
+
+// 或需要底层连接池句柄时:
+var sqlDB *sql.DB
+app.Find(&sqlDB)             // migration 就是拿它跑 goose
+```
+
+`Close()` 关闭底层 `sql.DB`([feature/gorm.go:53](../../feature/gorm.go#L53))。
+
+---
+
+## 支持的 driver
+
+`DB_DRIVER` 取值([feature/gorm.go:72](../../feature/gorm.go#L72)):
+
+| 值 | 驱动 |
+|---|---|
+| `mysql` | gorm.io/driver/mysql |
+| `sqlite` | gorm.io/driver/sqlite |
+| `postgres` / `postgresql` / `pgx` | gorm.io/driver/postgres(三个别名等价) |
+
+其它值 → 启动即 `log.Fatalf`。gorm 日志固定 Info 级([feature/gorm.go:65](../../feature/gorm.go#L65),不可配)。
+
+---
+
+## 连接池
+
+[feature/gorm.go:92](../../feature/gorm.go#L92):
+
+```go
+sqlDB.SetMaxIdleConns(MaxIdleConns)      // 无条件设
+sqlDB.SetMaxOpenConns(MaxOpenConns)      // 无条件设
+if ConnMaxLifetime > 0 { sqlDB.SetConnMaxLifetime(ConnMaxLifetime) }  // 可选
+if ConnMaxIdleTime > 0 { sqlDB.SetConnMaxIdleTime(ConnMaxIdleTime) }  // 可选
+```
+
+四个旋钮的语义:
+
+| 参数 | 作用 | 不设时 |
+|---|---|---|
+| `MaxOpenConns` | 连接总数硬上限 | 必填 |
+| `MaxIdleConns` | 保留的空闲连接数(高峰后池回落到这个数) | 必填,须 ≤ MaxOpenConns |
+| `ConnMaxLifetime` | 单连接最长可复用时长,到点回收 | 0 = 永不因年龄回收(可能被 MySQL `wait_timeout` 关掉后留下死连接) |
+| `ConnMaxIdleTime` | 空闲连接最长保留时长,到点关闭 | 0 = 空闲连接不因时长关闭,只受 MaxIdleConns 数量约束 |
+
+> **多服务共库要算总账**:所有连同一 MySQL 的服务,`MaxOpenConns × 副本数` 的**总和**必须 < MySQL `max_connections`,否则高并发下 `Error 1040: Too many connections`。
+>
+> `ConnMaxLifetime` 建议设为小于 DB `wait_timeout`(如 `1h`),规避低峰期陈旧连接;`ConnMaxIdleTime`(如 `5m`)能让闲置服务在低峰释放连接、给 DB 腾余量。二者都是**可选、向后兼容**(不设 = 保持原行为)。
+
+---
+
+## 环境变量
+
+| Env | 字段 | 必填 | 说明 |
+|---|---|---|---|
+| `DB_DRIVER` | Driver | 是 | 见上表 |
+| `DB_DSN` | DSN | 是 | 数据源连接串 |
+| `DB_MAX_IDLE_CONNS` | MaxIdleConns | 是(>0,≤MaxOpen) | 空闲连接数 |
+| `DB_MAX_OPEN_CONNS` | MaxOpenConns | 是(>0) | 连接总上限 |
+| `DB_CONN_MAX_LIFETIME` | ConnMaxLifetime | 否(omitempty) | duration;0/不设=永不回收 |
+| `DB_CONN_MAX_IDLE_TIME` | ConnMaxIdleTime | 否(omitempty) | duration;0/不设=不按空闲时长关 |
+
+校验规则见 [config/database.go:30](../../config/database.go#L30)。迁移用同一份 `DatabaseConfig` 决定 goose 方言,见 [migration.md](./migration.md)。

--- a/doc/features/i18n.md
+++ b/doc/features/i18n.md
@@ -1,0 +1,68 @@
+# I18N Feature(国际化)
+
+基于 `go-i18n/v2` 的多语言翻译。框架内置语言文件始终嵌入二进制,应用可再从磁盘目录叠加自己的翻译。
+
+源码:[feature/i18n_feature.go](../../feature/i18n_feature.go)、[config/i18n.go](../../config/i18n.go)、[contracts/i18n.go](../../contracts/i18n.go)
+
+---
+
+## 创建 & 用法
+
+```go
+app.AddFeature(feature.NewI18NFeature())
+```
+
+同时以两种类型注入([feature/i18n_feature.go:80](../../feature/i18n_feature.go#L80)):`I18NService` 和 `contracts.Translator`。**请求里翻译走 `RequestContext.T()`**(自动按请求语言),不用直接取 Translator:
+
+```go
+func Handler(c *contracts.RequestContext) (interface{}, bizerr.BizError) {
+    msg := c.T("error.not_found")          // 按请求语言翻译
+    msg2 := c.T("welcome", map[string]interface{}{"Name": "Bob"})  // 带模板数据
+    ...
+}
+```
+
+## Translator 接口
+
+[contracts/i18n.go:3](../../contracts/i18n.go#L3):
+
+```go
+T(id string, data ...interface{}) string
+TWithLang(lang, id string, data ...interface{}) string
+SetLang(lang string)
+GetLang() string
+SupportedLanguages() []string
+```
+
+行为([feature/i18n_feature.go:186](../../feature/i18n_feature.go#L186)):
+- `TWithLang` 的模板数据规则:`data[0]` 是 `map[string]interface{}` 直接用;否则单个 `data` 包成 `{"Value": data[0]}`。
+- **翻译不到时回退返回 message id 本身**(不报错,只 log)。
+
+## 请求级语言如何选(重点)
+
+feature 内部的 `currentLang` 是**实例级**的,请求级语言由 `RequestContext.GetLang()` 决定([contracts/request.go:15](../../contracts/request.go#L15)),优先级:
+
+```
+?lang= query  >  Accept-Language 首段  >  Translator 默认语言  >  "en"
+```
+
+`c.T()` 每次按 `GetLang()` 调 `TWithLang`,**不改变** feature 的 `currentLang`(并发安全)。
+
+## 语言文件加载
+
+- **框架内置**:`//go:embed i18n/*.yaml` 始终嵌入([feature/i18n_feature.go:20](../../feature/i18n_feature.go#L20)),覆盖框架自带的通用消息。
+- **应用目录**:`I18N_LOCALE_DIR`(默认 `locales`)下按 `<lang>.yaml/.yml/.toml/.json` 优先级加载([feature/i18n_feature.go:129](../../feature/i18n_feature.go#L129));目录不存在只 log、不报错。
+- 支持格式:yaml / yml / toml / json。
+
+> ⚠️ 配置字段 `LoadEmbedded`(`I18N_LOAD_EMBEDDED`)**当前代码里没被使用** —— 加载路径是硬编码的(框架嵌入 + 应用目录都会加载),这个开关不起作用。
+
+## 环境变量
+
+| Env | 字段 | 必填 | 代码兜底默认 |
+|---|---|---|---|
+| `I18N_DEFAULT_LANG` | DefaultLang | ❌(omitempty) | `en`(Setup 里兜底) |
+| `I18N_SUPPORTED_LANGS` | SupportedLangs | ❌(omitempty) | `["en","zh-CN"]` |
+| `I18N_LOCALE_DIR` | LocaleDir | ❌(omitempty) | `locales` |
+| `I18N_LOAD_EMBEDDED` | LoadEmbedded | ❌(omitempty) | (声明但未使用) |
+
+> 这些默认值是 `Setup` 里用 Go 代码兜底的([feature/i18n_feature.go:47](../../feature/i18n_feature.go#L47)),**不是** `envDefault`。`Validate` 要求 `DefaultLang` 必须在 `SupportedLangs` 内。

--- a/doc/features/jwt.md
+++ b/doc/features/jwt.md
@@ -1,0 +1,83 @@
+# JWT Feature
+
+签发 / 校验 access+refresh 双 token,支持基于 Redis 的**黑名单登出**。依赖 Redis feature(黑名单存 Redis),所以注册顺序要在 redis 之后。
+
+源码:[feature/jwt.go](../../feature/jwt.go)、[config/jwt.go](../../config/jwt.go)
+
+---
+
+## 创建 & 用法
+
+```go
+app.AddFeature(feature.NewJWTFeature())   // 必须在 NewRedisFeature() 之后
+```
+
+以接口 `JWTService` 注入([feature/jwt.go:63](../../feature/jwt.go#L63)):
+
+```go
+type authService struct {
+    JWT feature.JWTService `inject:""`
+}
+```
+
+## JWTService 接口
+
+[feature/jwt.go:23](../../feature/jwt.go#L23):
+
+```go
+GenerateToken(userID int64, email string, features []string) (*TokenResponse, error)
+ValidateToken(tokenString string) (*Claims, error)
+RefreshToken(tokenString string) (*TokenResponse, error)
+ExtractUserID(tokenString string) (int64, error)
+ValidateRefreshToken(tokenString string) (*Claims, error)
+Logout(accessToken, refreshToken string) error
+```
+
+- `TokenResponse`([feature/jwt.go:33](../../feature/jwt.go#L33)):`AccessToken` / `RefreshToken` / `ExpiresIn int64`(秒)。
+  > ⚠️ `ExpiresIn` **始终只反映 access 的寿命**(`ExpireTime`),即使在 `RefreshToken` 的返回里也是如此,不代表 refresh 寿命。
+- `Claims`([feature/jwt.go:39](../../feature/jwt.go#L39)):`jwt.RegisteredClaims` + `UserID` / `Email` / `Features`。
+
+## 签发
+
+`GenerateToken` 同时签 access + refresh([feature/jwt.go:80](../../feature/jwt.go#L80)):
+- access 寿命 = `JWT_EXPIRE_TIME`;refresh 寿命 = `RefreshExpireOrDefault()`;
+- 算法固定 `HS256`,密钥 `JWT_SECRET`;
+- 写入 `Issuer=JWT_ISSUER`、`Subject=userID`、`ID=jti`。
+
+### jti(每 token 唯一 ID)
+
+[feature/jwt.go:108](../../feature/jwt.go#L108) `newTokenID`:16 字节 `crypto/rand` → hex。**为什么必须有**:claims 其余字段对同一用户固定、时间戳只精确到秒,没有 jti 时**同一秒签发的两个 token 字节完全相同** → 按 token 拉黑会误伤同秒登录的其它设备、按 token 哈希做的会话管理无法区分设备。
+
+## 校验
+
+- `ValidateToken`:`parseClaims` → 查 access 黑名单,命中报 `token is blacklisted`([feature/jwt.go:143](../../feature/jwt.go#L143))。
+- `parseClaims`:强制 HMAC 签名方法,`token.Valid` 才通过([feature/jwt.go:242](../../feature/jwt.go#L242))。
+- `RefreshToken`:先 `ValidateRefreshToken`(含黑名单)+ 显式过期检查,再重签 access+refresh([feature/jwt.go:157](../../feature/jwt.go#L157))。
+
+## 黑名单登出(重点)
+
+key 前缀([feature/jwt.go:18](../../feature/jwt.go#L18)):
+- `jwt:blacklist:accesstoken:<完整token>`
+- `jwt:blacklist:refreshtoken:<完整token>`
+
+> key 用的是**完整 token 字符串**,不是 jti。
+
+`Logout(access, refresh)`([feature/jwt.go:269](../../feature/jwt.go#L269)):
+1. 分别校验两个 token、取其 `ExpiresAt`;
+2. `ttl = 剩余寿命`;`ttl <= 0`(已过期)则跳过不写;
+3. 否则 `Set(黑名单key, "1", ttl)` —— **黑名单条目 TTL 恰好等于 token 剩余寿命**,token 自然过期后条目自动清除,不留垃圾。
+
+> ⚠️ **Redis 故障时放行**:`ValidateToken`/`ValidateRefreshToken` 查黑名单用 `ok, _ :=` **忽略了 Redis 错误**([feature/jwt.go:150](../../feature/jwt.go#L150))→ Redis 挂了时"已登出"的 token 会被放行。这是 fail-open 取舍(不因 Redis 抖动打挂鉴权),需知悉。
+
+## 寿命配置
+
+`RefreshExpireOrDefault()`([config/jwt.go:24](../../config/jwt.go#L24)):`JWT_REFRESH_EXPIRE_TIME > 0` 用配置值,否则**默认 = `JWT_EXPIRE_TIME × 2`**。
+
+## 环境变量
+
+| Env | 字段 | 必填 | 说明 |
+|---|---|---|---|
+| `JWT_SECRET` | Secret | ✅ | 签名密钥;**不能等于占位默认值**(生产防呆,[config/jwt.go:31](../../config/jwt.go#L31)) |
+| `JWT_EXPIRE_TIME` | ExpireTime | ✅(>0) | access 寿命(duration) |
+| `JWT_ISSUER` | Issuer | ✅ | 签发者 |
+| `JWT_REFRESH_EXPIRE_TIME` | RefreshExpireTime | ❌(omitempty) | refresh 寿命;不设/0 → 默认 = access×2;不得为负 |

--- a/doc/features/mail.md
+++ b/doc/features/mail.md
@@ -1,0 +1,45 @@
+# Mail Feature(邮件)
+
+基于 `gopkg.in/mail.v2` 的 SMTP 发信,支持纯文本 / HTML / 两者混合。
+
+源码:[feature/mail.go](../../feature/mail.go)、[config/mail.go](../../config/mail.go)
+
+---
+
+## 创建 & 用法
+
+```go
+app.AddFeature(feature.NewMailFeature())
+```
+
+以接口 `EmailService` 注入([feature/mail.go:43](../../feature/mail.go#L43)):
+
+```go
+type EmailService interface {
+    SendText(ctx, to []string, subject, body string) error
+    SendHTML(ctx, to []string, subject, htmlBody string) error
+    Send(ctx, to []string, subject, textBody, htmlBody string) error   // 同时带 text+html
+}
+```
+
+行为([feature/mail.go:80](../../feature/mail.go#L80) `send`):
+- From 头:有 `MAIL_FROM_NAME` 时为 `Name <email>`,否则纯 email;
+- text+html 都给 → `text/plain` 正文 + `text/html` alternative;只给一个 → 对应类型;两个都空 → 报错;
+- 底层 `dialer.DialAndSend`。
+
+> ⚠️ 接口签名带 `ctx context.Context`,但**实际发信没用到 ctx**(不支持超时/取消)。
+
+## 环境变量 —— 全部强制必填(FromName 除外)
+
+`MailConfig.Validate` 强制校验([config/mail.go:16](../../config/mail.go#L16)),缺任一 → `Setup` 失败、进程不启动:
+
+| Env | 字段 | 必填 | 说明 |
+|---|---|---|---|
+| `MAIL_SMTP_HOST` | SMTPHost | ✅ | SMTP 主机 |
+| `MAIL_SMTP_PORT` | SMTPPort | ✅ | int,1–65535 |
+| `MAIL_SMTP_USER` | SMTPUser | ✅ | 用户名 |
+| `MAIL_SMTP_PASSWORD` | SMTPPassword | ✅ | 密码 |
+| `MAIL_FROM_EMAIL` | FromEmail | ✅ | 发件邮箱 |
+| `MAIL_FROM_NAME` | FromName | ❌(omitempty) | 发件人显示名 |
+
+> ⚠️ 因为**强制必填**,即使某服务不真的发信,也得给这些 env 填占位值(否则起不来)。homeserver 就用 `noop.invalid` 之类占位过校验。若希望"可选发信",要改成把这些字段标 `omitempty` 并在发信处判空 —— 当前实现不支持。

--- a/doc/features/migration.md
+++ b/doc/features/migration.md
@@ -1,0 +1,52 @@
+# 数据库迁移(Migration)
+
+基于 [goose](https://github.com/pressly/goose)(v3)的 SQL 迁移。不是 feature,而是一个在 `InitDefaultApp` 末尾调用的步骤。
+
+源码:[migration/migration.go](../../migration/migration.go)、[config/migration.go](../../config/migration.go)
+
+---
+
+## 怎么跑
+
+`InitDefaultApp` 在所有 feature 之后调用一次([bootstrap/default.go:25](../../bootstrap/default.go#L25)):
+
+```go
+migration.RunMigrations(a)
+```
+
+`RunMigrations`([migration/migration.go:17](../../migration/migration.go#L17))流程:
+1. 从 DI 容器取 `*sql.DB`(gorm feature 已 Provide);取不到报错;
+2. 按 `DB_DRIVER` 定 goose 方言(`postgres/postgresql/pgx`→postgres,`sqlite`→sqlite3,`mysql`→mysql);
+3. 读 `GOOSE_TABLE_PREFIX` 定版本表名;
+4. `goose.Up(sqlDB, <cwd>/migrations)`。
+
+**迁移文件目录固定为进程工作目录下的 `migrations/`**([migration/migration.go:68](../../migration/migration.go#L68)),不可配。没有迁移文件不算错误(返回 nil)。
+
+## 版本表前缀(多服务共库关键)
+
+多个服务共用一个数据库时,各自的 goose 版本表要隔离,否则版本号互相打架。用 `GOOSE_TABLE_PREFIX`([config/migration.go:10](../../config/migration.go#L10)):
+
+| `GOOSE_TABLE_PREFIX` | 版本表名 |
+|---|---|
+| (不设) | `goose_db_version` |
+| `admin_` | `admin_goose_db_version` |
+| `customer_` | `customer_goose_db_version` |
+
+homeserver 里 admin/customer/schedule 共库,就是靠不同前缀各记各的迁移进度。
+
+## worker 进程不该跑迁移
+
+迁移要独占执行,多个进程并发跑 goose 会抢锁 / 冲突。所以:
+- **API 进程**用 `InitDefaultApp`(含迁移);
+- **worker 进程**不要用 `InitDefaultApp`,自己 `app.NewApp()` + 手动 `AddFeature` 需要的子集,**跳过 `RunMigrations`**。
+
+homeserver 的 `wire.InitWorkerApp()` 就是这个模式。
+
+## 环境变量
+
+| Env | 必填 | 说明 |
+|---|---|---|
+| `GOOSE_TABLE_PREFIX` | ❌(omitempty) | 版本表前缀;不设 = `goose_db_version` |
+| 复用 `DB_DRIVER` | — | 决定 goose 方言 |
+
+> 迁移的 DB 连接直接复用 DI 里的 `*sql.DB`,无独立 DSN;目录固定 `migrations/`,无 env 可改。

--- a/doc/features/redis.md
+++ b/doc/features/redis.md
@@ -1,0 +1,93 @@
+# Redis Feature
+
+封装 go-redis(v8),把 `RedisService` 接口注入 DI 容器。除常规 KV/Hash 操作外,还提供带自动续租的分布式锁 `WithLock`。
+
+源码:[feature/redis.go](../../feature/redis.go)、[config/redis.go](../../config/redis.go)
+
+---
+
+## 创建 & 用法
+
+```go
+app.AddFeature(feature.NewRedisFeature())
+```
+
+以**接口类型**注入([feature/redis.go:69](../../feature/redis.go#L69)):
+
+```go
+type someService struct {
+    Redis feature.RedisService `inject:""`
+}
+```
+
+---
+
+## RedisService 方法表
+
+[feature/redis.go:15](../../feature/redis.go#L15) 接口,逐个:
+
+| 方法 | 签名 | 备注 |
+|---|---|---|
+| Get | `Get(ctx, key) (string, error)` | **key 不存在返回 `("", nil)`**(吞掉 `redis.Nil`) |
+| Set | `Set(ctx, key, value, expiration) error` | `expiration=0` = 永不过期 |
+| Delete | `Delete(ctx, keys...) (int64, error)` | 注意方法名是 `Delete` 不是 `Del` |
+| Exists | `Exists(ctx, key) (bool, error)` | |
+| Incr | `Incr(ctx, key) (int64, error)` | |
+| SetNX | `SetNX(ctx, key, value, expiration) (bool, error)` | 成功抢到返回 true |
+| HSet | `HSet(ctx, key, field, value) error` | 单 field |
+| HGet | `HGet(ctx, key, field) (string, error)` | 不存在返回 `("", nil)` |
+| HDel | `HDel(ctx, key, fields...) (int64, error)` | |
+| HGetAll | `HGetAll(ctx, key) (map[string]string, error)` | |
+| HExists | `HExists(ctx, key, field) (bool, error)` | |
+| HKeys | `HKeys(ctx, key) ([]string, error)` | |
+| Expire | `Expire(ctx, key, expiration) error` | |
+| WithLock | `WithLock(ctx, key, value, ttl, fn) error` | 见下 |
+
+> ⚠️ `Get` / `HGet` 把 "不存在" 和 "空值" 都返回成 `("", nil)` —— 判断存在性要用 `Exists`,别靠 `Get` 的错误。
+
+---
+
+## WithLock —— 分布式锁(重点)
+
+[feature/redis.go:180](../../feature/redis.go#L180):
+
+```go
+err := redis.WithLock(ctx, "lock:daily-settle", instanceID, 30*time.Second, func() error {
+    return doHeavyJob()   // 只有抢到锁的实例会执行
+})
+if errors.Is(err, feature.ErrLockNotAcquired) {
+    // 别的实例正在跑,本次跳过(不是错误)
+}
+```
+
+**语义 —— 是 "skip-if-running",不是排队等待**:
+
+- **获取**:`SetNX(key, value, ttl)`。抢不到锁 → **立即返回 `ErrLockNotAcquired`,`fn` 不执行**([feature/redis.go:186](../../feature/redis.go#L186))。不阻塞、不重试。
+- **自动续租**:后台 goroutine 每 `ttl/2`(最小 1s)续一次([feature/redis.go:197](../../feature/redis.go#L197))。续租前先 `GET` 校验锁值仍是自己写的 `value` 才 `EXPIRE`,防止续别人的锁。→ **`fn` 跑再久也不会因 ttl 到期被别人抢走**,同时进程崩了锁按 ttl 自动释放。
+- **释放**:`fn` 返回后 `defer` 里停续租 goroutine,再用独立 5s 超时 `DEL key`。释放失败只告警(靠 ttl 兜底)。
+- **返回值**:直接透传 `fn()` 的返回。
+
+用途:周期性后台任务防重复执行(多副本 worker 里,同一任务只有一个实例真跑)。
+
+> ⚠️ 释放时直接 `DEL`,**没做 value 比对(无 Lua CAS)**。理论上若 `fn` 执行超过 ttl 且续租失败、锁被他人抢占,释放会误删他人锁。实践中 ttl 给足 + 续租正常时不触发,但要清楚这个边界。
+
+导出错误:`var ErrLockNotAcquired`([feature/redis.go:172](../../feature/redis.go#L172))。
+
+---
+
+## 连接池 & 版本
+
+- 用的是 **go-redis v8**(`github.com/go-redis/redis/v8`)。
+- `provideRedis` 只设了 `Addr/Password/DB`,**没设 `PoolSize`**([feature/redis.go:80](../../feature/redis.go#L80))→ 走 go-redis 默认池大小(`10 × GOMAXPROCS`)。高并发 + 无 CPU 限制时每容器 `GOMAXPROCS` 可能偏大,注意评估。
+
+---
+
+## 环境变量
+
+| Env | 字段 | 必填 | 说明 |
+|---|---|---|---|
+| `REDIS_ADDR` | Addr | 是 | `host:port` |
+| `REDIS_PASSWORD` | Password | **是(非空)** | 无密码 Redis 也得填非空占位(如 `none`) |
+| `REDIS_DB` | DB | 是(≥0) | DB 编号 |
+
+> ⚠️ `REDIS_PASSWORD` **强制非空**([config/redis.go:18](../../config/redis.go#L18))—— 这是常见的启动失败原因。无密码环境填任意非空串。无 `PoolSize` 等池相关 env。

--- a/doc/features/server.md
+++ b/doc/features/server.md
@@ -1,0 +1,151 @@
+# Server Feature
+
+HTTP 服务器 feature —— 封装 gin engine、路由注册、统一 handler 约定、CORS、健康检查、优雅停机。它是**唯一必须最先注册**的 feature(App 对它有特殊处理,见 [architecture.md §2.3](../architecture.md))。
+
+源码:[feature/server.go](../../feature/server.go)、[config/server.go](../../config/server.go)、[contracts/server.go](../../contracts/server.go)、[contracts/route.go](../../contracts/route.go)、[contracts/request.go](../../contracts/request.go)
+
+---
+
+## 创建
+
+```go
+server := feature.NewServerFeature()                       // 默认
+server := feature.NewServerFeature(                        // 带自定义错误处理器
+    feature.WithErrorHandler(myErrorHandler),
+)
+app.AddFeature(server)
+```
+
+- `NewServerFeature(opts ...ServerOption)` — [feature/server.go:45](../../feature/server.go#L45)
+- 目前唯一 option:`WithErrorHandler(contracts.ErrorHandler)` — [feature/server.go:39](../../feature/server.go#L39),替换默认错误响应格式。
+
+`Setup` 里:注入 `ServerConfig` → `Validate` → 构建 gin engine → 把 `*gin.Engine` Provide 进容器([feature/server.go:60](../../feature/server.go#L60))。
+
+---
+
+## 定义路由
+
+路由是 `contracts.Route` 的列表([contracts/route.go:10](../../contracts/route.go#L10)):
+
+```go
+type Route struct {
+    Method      string                 // "GET" / "POST" / "PUT" / "DELETE" / "PATCH"
+    Path        string
+    Handler     CustomizedHandlerFunc
+    Middlewares []gin.HandlerFunc      // 按序在业务 handler 之前执行
+}
+```
+
+注册:
+
+```go
+app.RegisterRoutes([]contracts.Route{
+    {Method: "GET", Path: "/api/customer", Handler: customer.GetCustomer,
+     Middlewares: []gin.HandlerFunc{jwtMiddleware, entitlementMiddleware}},
+})
+```
+
+> `RegisterRoutes` 只是**追加缓存**([feature/server.go:79](../../feature/server.go#L79)),真正挂到 gin 是在 `Start()` 时的 `setupRoutes()`。中间件数组会被拼在业务 handler **前面**(`append(r.Middlewares, handler)`),即中间件先跑。
+
+---
+
+## Handler 约定(重点)
+
+Aurora 不用裸 `gin.HandlerFunc`,而是自定义签名([contracts/route.go:8](../../contracts/route.go#L8)):
+
+```go
+type CustomizedHandlerFunc func(*RequestContext) (interface{}, bizerr.BizError)
+```
+
+**你只管返回 `(数据, 错误)`,框架负责序列化和错误响应**:
+
+```go
+func GetCustomer(c *contracts.RequestContext) (interface{}, bizerr.BizError) {
+    id, _ := middleware.GetUserID(c)
+    dto, err := svc.Get(c.Context, id)
+    if err != nil {
+        return nil, bizerr.ErrNotFound()   // → 框架按 BizError 的 HTTPCode/Message 响应
+    }
+    return dto, nil                        // → 框架 c.JSON(200, dto)
+}
+```
+
+包装逻辑([feature/server.go:281](../../feature/server.go#L281) `createHandler`):
+- `bizErr != nil` → 走错误处理器输出;
+- 否则若 handler **没自己写过响应**(`!c.Writer.Written()`)→ `c.JSON(200, data)`;
+- 若 handler 自己写了(`c.Data` / `c.String` / 流式)→ 框架不再序列化,避免多写一个 `null`。
+
+### RequestContext
+
+[contracts/request.go:9](../../contracts/request.go#L9) —— 内嵌 `*gin.Context`,额外带 `App` 和 `Translator`:
+
+```go
+c.Context          // 原始 *gin.Context(取 param/query/body、写响应)
+c.App              // DI 容器,可 Find 依赖
+c.GetLang()        // 请求语言:?lang= → Accept-Language 首段 → Translator 默认 → "en"
+c.T("error.xxx")   // 按 GetLang() 翻译(见 i18n.md)
+```
+
+---
+
+## 错误响应
+
+默认错误格式([feature/server.go:313](../../feature/server.go#L313) `defaultHandleError`):
+
+```json
+{ "message": "<bizErr.Message()>" }   // HTTP 状态码 = bizErr.HTTPCode()
+```
+
+想改格式 → `WithErrorHandler` 传自定义 `contracts.ErrorHandler`。BizError 模型详见 [bizerr.md](./bizerr.md)。
+
+---
+
+## 健康检查
+
+`setupRoutes` 会**先**注册两个端点([feature/server.go:237](../../feature/server.go#L237)),无需自己写:
+
+| 端点 | 返回 |
+|---|---|
+| `GET /health` | `{status:"healthy", service, version, timestamp}` 200 |
+| `GET /ready` | `{status:"ready", service}` 200 |
+
+swarm / k8s 的存活探针直接打 `/health` 即可。
+
+---
+
+## 优雅停机
+
+启动时起两个 goroutine([feature/server.go:83](../../feature/server.go#L83) `Start`):`startServer()`(`ListenAndServe`)+ `signalListener()`。
+
+停机链路([feature/server.go:154](../../feature/server.go#L154)):
+
+```
+signal.Notify(SIGINT, SIGTERM)  →  收到信号
+   → server.Shutdown(ctx)        // ctx 超时 = SHUTDOWN_TIMEOUT
+   → 排空在途请求;超时则强制关闭并打印 "shutdown timeout ... forcing close"
+   → Wait() 返回 → app.Run() 返回
+```
+
+- 超时来自 `SHUTDOWN_TIMEOUT`([config/server.go:33](../../config/server.go#L33),默认 5s)。
+- ⚠️ **只关 HTTP server**,不会自动关其它 feature、也不排空后台任务(如 asynq)。后台任务的排空要在 `main` 里自己编排 —— 见 [architecture.md §2.5](../architecture.md)。
+- ⚠️ 超过 `SHUTDOWN_TIMEOUT` 的长请求(大文件上传等)会被硬切;部署时需把容器 `stop_grace_period` 设得比它大。
+
+---
+
+## 环境变量
+
+> ⚠️ **重要坑**:`ServerConfig`([config/server.go:27](../../config/server.go#L27))每个字段都写了 `envDefault:"..."`,**但 `ResolveConfig` 根本不读 `envDefault`**(见 [config.md](./config.md)),而且这些字段**没有 `omitempty`** —— 所以它们全是**必填**。下表"envDefault 标注值"那列**运行时不会生效**,不设对应环境变量 = 启动直接报 required 错误。部署时这些 env 必须逐个显式设置。
+
+| Env | 类型 | 必填 | envDefault 标注(不生效) | 说明 |
+|---|---|---|---|---|
+| `HOST` | string | ✅ | `0.0.0.0` | 监听地址,须是合法 IP |
+| `PORT` | int | ✅ | `8080` | 1–65535 |
+| `READ_TIMEOUT` | duration | ✅ | `30s` | 读超时 |
+| `WRITE_TIMEOUT` | duration | ✅ | `30s` | 写超时 |
+| `IDLE_TIMEOUT` | duration | ✅ | `60s` | keep-alive 空闲超时 |
+| `SHUTDOWN_TIMEOUT` | duration | ✅ | `5s` | 优雅停机排空超时 |
+| `SERVICE_NAME` | string | ✅ | `myapp` | 服务名(banner / 健康检查) |
+| `SERVICE_VERSION` | string | ✅ | `1.0.0` | 版本 |
+| `RUN_LEVEL` | string | ✅ | `local` | `local`/`eng`/`stage`/`production`;=production 时 gin 走 release 模式 |
+
+CORS 走独立的 `CORSConfig`([config/cors.go](../../config/cors.go)):`CORS_ALLOWED_ORIGINS` / `_METHODS` / `_HEADERS` / `_CREDENTIALS`(前三个是逗号分隔列表)。**三个列表全空 = 不启用 CORS**;任一非空则三者都要填。


### PR DESCRIPTION
## 背景

aurora 此前只有一个单文件 `README.md`(快速开始 + 配置清单 + 架构散文糊在一起),**没有成体系的 per-feature 深度文档**。新人要搞清某个 feature 的真实行为/坑,只能翻源码。

## 改动

新建 `doc/` 树,全部贴真实代码、标注 `文件:行号`:

- **[architecture.md](doc/architecture.md)** —— App 生命周期 / Feature 系统 / 依赖注入 / 启停时序图
- **[features/config.md](doc/features/config.md)** —— 配置系统 `ResolveConfig`(核心机制)
- **features/** 下 8 篇:`server` / `gorm` / `redis` / `jwt` / `i18n` / `mail` / `migration` / `bizerr`(错误模型+logger)
- **[doc/README.md](doc/README.md)** —— 索引 + 6 大通用坑 + 待改进项清单

## 顺带扒出的 4 个框架缺口(已记进 doc/README「待改进项」)

写文档时读代码发现的真实问题,**本 PR 不改代码只记录**,供后续 fixup:

1. `config/server.go` 的 `envDefault` 标签是**死代码** —— `ResolveConfig` 不读它,且字段无 `omitempty` = 实际必填,默认值永不生效。
2. `i18n` 的 `LoadEmbedded`(`I18N_LOAD_EMBEDDED`)声明了但从未被读取。
3. `mail` 全字段强制必填,不利于「可选发信」场景。
4. `RedisService` 未设 `PoolSize`,高并发走默认池(`10×GOMAXPROCS`)。

## ⚠️ 合并顺序

`doc/features/gorm.md` 记录了 `ConnMaxLifetime` / `ConnMaxIdleTime` 两个字段,它们由 #37 引入。**请先合 #37 再合本 PR**,否则文档会短暂描述 main 上尚不存在的字段。其余文档均对齐当前 main。