### PR TITLE
feat(server): configurable trusted proxies so c.ClientIP() is trustworthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight, modular web framework for Go, built on top of Gin with dependency
 - ⚙️ **Configuration Management**: Environment-based configuration loading with validation
 - 🛡️ **Error Handling**: Unified business error handling with validation error support
 - 🌐 **CORS Support**: Configurable CORS middleware
+- 🕵️ **Trusted Proxies**: Configurable trusted-proxy list so `c.ClientIP()` returns the real client IP behind a reverse proxy and can't be spoofed via `X-Forwarded-For` (secure-by-default: trusts private ranges only)
 - 🔒 **Route Middlewares**: Support for route-specific Gin middlewares (e.g., JWT authentication, rate limiting)
 - 🏥 **Health Checks**: Built-in `/health` and `/ready` endpoints
 - 📝 **Request Context**: Extended request context with App instance for easy dependency access
@@ -138,6 +139,7 @@ Aurora uses environment variables for configuration. All configurations are vali
 - `READ_TIMEOUT`: Read timeout (default: `30s`)
 - `WRITE_TIMEOUT`: Write timeout (default: `30s`)
 - `SHUTDOWN_TIMEOUT`: Graceful shutdown timeout (default: `5s`)
+- `TRUSTED_PROXIES`: Comma-separated proxy IPs/CIDRs whose `X-Forwarded-For` is trusted for `c.ClientIP()` (optional). Unset → loopback + RFC1918 private ranges; `none` → trust nobody (client IP = direct peer); `0.0.0.0/0,::/0` → trust all (legacy gin default). See [Server feature docs](doc/features/server.md#可信代理--真实客户端-ip).
 
 **Note**: Gin mode is automatically set based on `RUN_LEVEL`:
 

--- a/config/server.go
+++ b/config/server.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -12,6 +13,23 @@ const (
 	RunLevelStage      = "stage"
 	RunLevelProduction = "production"
 )
+
+// TrustedProxiesNone 是 TRUSTED_PROXIES 的显式哨兵值:谁都不信任,
+// c.ClientIP() 一律返回直连对端 IP、绝不采信任何 X-Forwarded-For。
+const TrustedProxiesNone = "none"
+
+// DefaultTrustedProxies 是 TRUSTED_PROXIES 未设置时的默认可信代理网段:
+// loopback + RFC1918 私网 + IPv6 loopback/ULA。它匹配 aurora 服务最常见的部署形态
+// ——服务只经私有网(容器网 / 内网)里的反向代理可达。于是:来自反代(私网 IP)的请求
+// 才解析 X-Forwarded-For 拿到真实客户端 IP;直连公网的请求不被信任、无法伪造 XFF。
+var DefaultTrustedProxies = []string{
+	"127.0.0.0/8",
+	"::1/128",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+}
 
 var ValidRunLevels = map[string]bool{
 	RunLevelLocal:      true,
@@ -35,6 +53,20 @@ type ServerConfig struct {
 	Name     string `env:"SERVICE_NAME" envDefault:"myapp"`
 	Version  string `env:"SERVICE_VERSION" envDefault:"1.0.0"`
 	RunLevel string `env:"RUN_LEVEL" envDefault:"local"`
+
+	// TrustedProxies 决定 gin 采信哪些代理转发的 X-Forwarded-For / X-Real-IP,
+	// 即 c.ClientIP() 拿到的到底是真实客户端 IP 还是可被伪造的值。只有当请求的**直接对端**
+	// 落在这些网段内时,gin 才解析 XFF;否则 c.ClientIP() 用直连对端 IP。
+	//
+	//   - 不设(空)        → 用 DefaultTrustedProxies(loopback + RFC1918 私网),
+	//                        开箱即"反代后拿真 IP + 直连公网无法伪造"。
+	//   - "none"           → 谁都不信,c.ClientIP() 恒为直连对端。
+	//   - "0.0.0.0/0,::/0" → 信任所有代理(gin 历史默认,可被伪造 XFF,不推荐)。
+	//   - "<cidr,...>"     → 精确信任这些 IP/CIDR(如只信你的反代地址)。
+	//
+	// 注意:相对 gin 默认("信任所有代理")这是一次安全硬化,会影响所有读 c.ClientIP() 的代码。
+	// 用 ,omitempty(可选)+ 默认值写在代码里(见 DefaultTrustedProxies)—— envDefault 在本框架不生效。
+	TrustedProxies []string `env:"TRUSTED_PROXIES,omitempty"`
 }
 
 func (s *ServerConfig) Key() string {
@@ -59,7 +91,34 @@ func (s *ServerConfig) Validate() error {
 		return NewConfigError(fmt.Sprintf("RUN_LEVEL must be one of: %s", validRunLevelsString()))
 	}
 
+	// 可信代理:对解析出的最终网段逐个校验(非法 IP/CIDR 直接 fail-fast)。
+	for _, p := range s.ResolvedTrustedProxies() {
+		if !isValidProxyEntry(p) {
+			return NewConfigError(fmt.Sprintf("TRUSTED_PROXIES contains an invalid IP or CIDR: %q", p))
+		}
+	}
+
 	return nil
+}
+
+// ResolvedTrustedProxies 把 TrustedProxies 解析成最终传给 gin SetTrustedProxies 的网段列表:
+// 未设 → DefaultTrustedProxies(私网);单个 "none" 哨兵 → 空(谁都不信);否则原样返回。
+func (s *ServerConfig) ResolvedTrustedProxies() []string {
+	if len(s.TrustedProxies) == 0 {
+		return DefaultTrustedProxies
+	}
+	if len(s.TrustedProxies) == 1 && strings.EqualFold(strings.TrimSpace(s.TrustedProxies[0]), TrustedProxiesNone) {
+		return []string{}
+	}
+	return s.TrustedProxies
+}
+
+// isValidProxyEntry 接受 CIDR(如 10.0.0.0/8)或裸 IP(如 1.2.3.4)—— 与 gin SetTrustedProxies 的接受面一致。
+func isValidProxyEntry(entry string) bool {
+	if _, _, err := net.ParseCIDR(entry); err == nil {
+		return true
+	}
+	return net.ParseIP(entry) != nil
 }
 
 func (s *ServerConfig) IsProduction() bool {

--- a/config/server_test.go
+++ b/config/server_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func baseServerConfig() *ServerConfig {
+	return &ServerConfig{Host: "0.0.0.0", Port: 8080, Name: "svc", RunLevel: RunLevelLocal}
+}
+
+func TestResolvedTrustedProxies(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"unset uses private default", nil, DefaultTrustedProxies},
+		{"empty uses private default", []string{}, DefaultTrustedProxies},
+		{"none sentinel trusts nobody", []string{"none"}, []string{}},
+		{"NONE is case-insensitive", []string{" NONE "}, []string{}},
+		{"explicit cidrs pass through", []string{"192.168.1.0/24", "10.1.2.3"}, []string{"192.168.1.0/24", "10.1.2.3"}},
+		{"trust-all restores gin legacy", []string{"0.0.0.0/0", "::/0"}, []string{"0.0.0.0/0", "::/0"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &ServerConfig{TrustedProxies: tc.in}
+			if got := s.ResolvedTrustedProxies(); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("ResolvedTrustedProxies() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateTrustedProxies(t *testing.T) {
+	// Valid: unset (default), sentinel, and correct IP/CIDR lists all pass.
+	for _, in := range [][]string{nil, {"none"}, {"10.0.0.0/8"}, {"1.2.3.4"}, {"0.0.0.0/0", "::/0"}} {
+		c := baseServerConfig()
+		c.TrustedProxies = in
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate() unexpected error for %v: %v", in, err)
+		}
+	}
+	// Invalid CIDR/IP → error.
+	for _, in := range [][]string{{"not-an-ip"}, {"10.0.0.0/8", "999.0.0.1"}, {"10.0.0.0/33"}} {
+		c := baseServerConfig()
+		c.TrustedProxies = in
+		if err := c.Validate(); err == nil {
+			t.Fatalf("Validate() expected error for %v, got nil", in)
+		}
+	}
+}

--- a/doc/features/config.md
+++ b/doc/features/config.md
@@ -54,6 +54,8 @@ func (c *MyConfig) Validate() error {
 
 **永远不要用 `envDefault`**,它是死标签。
 
+> 框架内的正面范例:`ServerConfig.TrustedProxies`([config/server.go](../../config/server.go))—— `env:"TRUSTED_PROXIES,omitempty"`(可选)+ 默认值 `DefaultTrustedProxies` 写在代码、由 `ResolvedTrustedProxies()` 兜底。加带默认值的可选配置照它抄,别照 `HOST`/`PORT` 那套 `envDefault`。
+
 ## 支持的字段类型
 
 [config/resolve.go:57](../../config/resolve.go#L57) `setFieldValue`:

--- a/doc/features/server.md
+++ b/doc/features/server.md
@@ -147,5 +147,27 @@ signal.Notify(SIGINT, SIGTERM)  →  收到信号
 | `SERVICE_NAME` | string | ✅ | `myapp` | 服务名(banner / 健康检查) |
 | `SERVICE_VERSION` | string | ✅ | `1.0.0` | 版本 |
 | `RUN_LEVEL` | string | ✅ | `local` | `local`/`eng`/`stage`/`production`;=production 时 gin 走 release 模式 |
+| `TRUSTED_PROXIES` | `[]string` | ❌(omitempty) | —(默认写在代码里) | 可信代理 IP/CIDR。见下方[「可信代理」](#可信代理--真实客户端-ip)。**这一项是正确写法**:`,omitempty` + 默认值在代码(`DefaultTrustedProxies`),不踩 `envDefault` 的坑 |
+
+> 📌 `TRUSTED_PROXIES` 与上表其余字段不同 —— 它带 `,omitempty`(可选)、默认值写在代码里,是**加配置的正确姿势**;其余字段那套"`envDefault` + 无 omitempty"是历史遗留坑(见 [config.md](./config.md)),别照抄。
 
 CORS 走独立的 `CORSConfig`([config/cors.go](../../config/cors.go)):`CORS_ALLOWED_ORIGINS` / `_METHODS` / `_HEADERS` / `_CREDENTIALS`(前三个是逗号分隔列表)。**三个列表全空 = 不启用 CORS**;任一非空则三者都要填。
+
+---
+
+## 可信代理 · 真实客户端 IP
+
+`c.ClientIP()`(gin)拿到的是不是**真实**客户端 IP,取决于「信任哪些代理」。gin 的默认是**信任所有代理**——即无条件采信请求头里的 `X-Forwarded-For` / `X-Real-IP`。这在反代后能拿到真 IP,但**任何客户端都能伪造 `X-Forwarded-For` 冒充任意 IP**。凡是拿 `c.ClientIP()` 做审计、限流、IP 白名单/黑名单的地方,这就是个洞。
+
+Aurora 用 `SetTrustedProxies` 收敛:**只有请求的直接对端(TCP peer)落在可信网段内时,才解析 XFF;否则 `c.ClientIP()` 用直连对端 IP。** 由 `TRUSTED_PROXIES`(`config.ServerConfig.TrustedProxies`)控制:
+
+| `TRUSTED_PROXIES` 取值 | 行为 |
+|---|---|
+| **不设**(默认) | 信任 `DefaultTrustedProxies` = loopback + RFC1918 私网([config/server.go](../../config/server.go));反代在私网里→拿真 IP,直连公网→无法伪造 |
+| `none` | 谁都不信,`c.ClientIP()` **恒为直连对端** IP |
+| `10.0.0.0/8,1.2.3.4` | 精确信任这些 IP/CIDR(如只信你的反代地址),逗号分隔 |
+| `0.0.0.0/0,::/0` | 信任所有代理,**恢复 gin 历史默认**(可被伪造,不推荐) |
+
+- 非法 IP/CIDR 在 `ServerConfig.Validate()` 直接报错(fail-fast)。
+- ⚠️ **行为变更**:相对 gin 原生默认("信任所有代理"),Aurora 默认改为"只信私网/loopback"。这是安全硬化。若你的应用**直连公网无反代**、或反代不在私网,请显式设 `TRUSTED_PROXIES`(直连无反代场景建议 `none`;反代不在私网则填反代的实际 IP/CIDR)。
+- 部署形态:典型是"服务只经私网里的 traefik/nginx 反代可达",默认值即开箱可用,无需配置。

--- a/feature/server.go
+++ b/feature/server.go
@@ -202,6 +202,12 @@ func (f *serverFeature) createGinEngine() *gin.Engine {
 	engine.Use(gin.Logger())
 	engine.Use(gin.Recovery())
 
+	// 可信代理:决定 c.ClientIP() 是否采信代理转发的 X-Forwarded-For(否则用直连对端 IP,防伪造)。
+	// 见 config.ServerConfig.TrustedProxies —— 默认只信私网/loopback,可用 TRUSTED_PROXIES 调整。
+	if err := engine.SetTrustedProxies(f.Config.ResolvedTrustedProxies()); err != nil {
+		log.Fatalf("Failed to set trusted proxies (TRUSTED_PROXIES): %v", err)
+	}
+
 	if err := f.setupCORS(engine); err != nil {
 		log.Fatalf("Failed to setup CORS: %v", err)
 	}


### PR DESCRIPTION
## 问题

gin 默认 **信任所有代理**(`trustedProxies = 0.0.0.0/0`)→ `c.ClientIP()` 无条件采信请求头里的 `X-Forwarded-For` / `X-Real-IP`。反代后能拿到真 IP,但**任何客户端都能伪造 `X-Forwarded-For` 冒充任意 IP**。凡是用 `c.ClientIP()` 做审计 / 限流 / IP 白名单/黑名单的地方,这就是个可绕过的洞。

## 改动

`ServerConfig` 新增 `TrustedProxies []string`(env `TRUSTED_PROXIES`,逗号分隔 IP/CIDR);建 gin engine 时 `engine.SetTrustedProxies(...)`。只有请求的**直接对端(TCP peer)**落在可信网段内,才解析 XFF;否则 `c.ClientIP()` 用直连对端 IP。

| `TRUSTED_PROXIES` | 行为 |
|---|---|
| **不设**(默认) | `DefaultTrustedProxies` = loopback + RFC1918 私网 —— 反代在私网→拿真 IP,直连公网→无法伪造 |
| `none` | 谁都不信,`c.ClientIP()` 恒为直连对端 |
| `10.0.0.0/8,1.2.3.4` | 精确信任这些 IP/CIDR |
| `0.0.0.0/0,::/0` | 恢复 gin 历史"全信"(不推荐) |

- **通用框架姿势**:`,omitempty`(可选)+ 默认值写在代码(`DefaultTrustedProxies` / `ResolvedTrustedProxies()`)—— 不踩本框架 `envDefault` 死标签的坑;非法 IP/CIDR 在 `ServerConfig.Validate()` fail-fast。
- 单测:`config/server_test.go` 覆盖默认 / `none` 哨兵 / 精确网段 / 非法值校验。

## ⚠️ 行为变更(使用方注意)

相对 gin 原生默认(**信任所有代理**),本框架默认改为**只信私网/loopback**(安全硬化,影响所有读 `c.ClientIP()` 的代码)。
- 反代在私网(容器网/内网)= 主流部署 → **默认即可用,无需配置**。
- 应用**直连公网、无反代** → 显式设 `TRUSTED_PROXIES=none`。
- 反代不在私网 → 填反代的实际 IP/CIDR。
- 想完全恢复旧行为 → `TRUSTED_PROXIES=0.0.0.0/0,::/0`。

## 文档

- `doc/features/server.md`:env 表加 `TRUSTED_PROXIES` 行 + 新增「可信代理 · 真实客户端 IP」章节。
- `README.md`:配置清单 + Features 列表。
- `doc/features/config.md`:作为"`omitempty` + 代码默认"的正面范例引用。

## 验证

`go build ./...` / `go test ./config/...` / `go vet ./config/` 全绿;`gofmt` 干净。