### PR TITLE
docs(mail): rewrite for the new feature/mail package

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Aurora 框架文档
 
-Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 邮件 + 迁移」收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、按环境变量配置、统一启停。
+Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 迁移」收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、按环境变量配置、统一启停。发信是**独立的库**(`feature/mail`,非自动注册的 Feature、不读 env),按需构造。
 
 > 快速上手和完整示例见仓库根 [README.md](../README.md) 与 [sample/](../sample/)。本目录是**成体系的深度文档**:讲清每个机制的真实行为和坑。
 
@@ -18,7 +18,7 @@ Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数
 | [redis](./features/redis.md) | Redis 封装、分布式锁 | `WithLock` 是 skip-if-running;`REDIS_PASSWORD` 强制非空 |
 | [jwt](./features/jwt.md) | access/refresh token、黑名单登出 | jti;黑名单 TTL=剩余寿命;Redis 故障 fail-open |
 | [i18n](./features/i18n.md) | 多语言翻译 | 请求语言:`?lang=`>Accept-Language;`LoadEmbedded` 未用 |
-| [mail](./features/mail.md) | SMTP 发信 | MAIL_* 全强制必填,不发信也要填占位 |
+| [mail](./features/mail.md) | 发信(供应商无关,SMTP + 可插拔授权) | **不是 Feature**:不走 `AddFeature`、不读 env;`mail.NewSMTP(...)` 按需构造 |
 | [migration](./features/migration.md) | goose 迁移 | `GOOSE_TABLE_PREFIX` 隔离共库版本表;worker 别跑迁移 |
 | [错误模型 & 日志](./features/bizerr.md) | bizerr / logger | 默认响应只含 message;LOG_LEVEL>RUN_LEVEL |
 
@@ -39,5 +39,4 @@ Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数
 
 - `config/server.go` 的 `envDefault` 标签是死代码,建议要么让 `ResolveConfig` 真正支持 `envDefault`,要么删掉这些误导标签并给字段加 `omitempty` + 代码默认值。
 - `i18n` 的 `LoadEmbedded`(`I18N_LOAD_EMBEDDED`)声明了但从未被读取,要么接上要么删。
-- `mail` 全字段强制必填,不利于"可选发信"场景,可考虑改 `omitempty` + 用时判空。
 - `RedisService` 未设 `PoolSize`,高并发下走默认池(`10×GOMAXPROCS`),可考虑做成可配。

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -3,7 +3,7 @@
 > 本文讲 Aurora 的"骨架"——App 生命周期、Feature 系统、依赖注入、配置解析。
 > 各 Feature 的具体用法见 [features/](./features/)。
 
-Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 邮件 + 迁移」这些每个服务都要重写的基础设施,收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、统一按环境变量配置、统一启停。
+Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数据库 + Redis + JWT + i18n + 迁移」这些每个服务都要重写的基础设施,收敛成一组可插拔的 **Feature**,用一个 **App** 容器统一装配、统一按环境变量配置、统一启停。(发信不在此列 —— 它是独立的 `feature/mail` 库,非 Feature、不读 env,按需构造,见 [features/mail.md](./features/mail.md)。)
 
 ---
 
@@ -56,7 +56,7 @@ func InitDefaultApp() contracts.App {
     a.AddFeature(feature.NewRedisFeature()) // Redis
     a.AddFeature(feature.NewJWTFeature())   // JWT(依赖 Redis 做黑名单)
     a.AddFeature(feature.NewI18NFeature())  // i18n
-    a.AddFeature(feature.NewMailFeature())  // 邮件
+    // 邮件不再是自动注册的 feature —— 用 feature/mail 包按需构造 Mailer(见 doc/features/mail.md)
 
     migration.RunMigrations(a)           // ★ 最后跑 DB 迁移
     return a
@@ -141,7 +141,6 @@ main
  │    ├─ AddFeature(redis) ──────── redis.Setup(app)    [连 Redis, Provide RedisService]
  │    ├─ AddFeature(jwt) ────────── jwt.Setup(app)      [取 RedisService, Provide JWT]
  │    ├─ AddFeature(i18n) ───────── i18n.Setup(app)     [加载 locale]
- │    ├─ AddFeature(mail) ───────── mail.Setup(app)     [校验 SMTP 配置]
  │    └─ RunMigrations(app) ─────── [用 *gorm.DB 跑 goose]
  │
  ├─ app.RegisterRoutes(routes) ──── serverFeature.RegisterRoutes()

--- a/doc/features/mail.md
+++ b/doc/features/mail.md
@@ -1,45 +1,121 @@
-# Mail Feature(邮件)
+# Mail(邮件)
 
-基于 `gopkg.in/mail.v2` 的 SMTP 发信,支持纯文本 / HTML / 两者混合。
+供应商无关的发信抽象。调用方只依赖 `Mailer.Send(ctx, Message)`,用**自己的配置来源**(env / 数据库 / 临时)构造具体 `Mailer` —— 换供应商、换授权方式、换凭据来源都不动调用点。
 
-源码:[feature/mail.go](../../feature/mail.go)、[config/mail.go](../../config/mail.go)
+包:`github.com/shyandsy/aurora/feature/mail`
+源码:[mailer.go](../../feature/mail/mailer.go)(接口/Message)、[smtp.go](../../feature/mail/smtp.go)(SMTP 供应商)、[auth.go](../../feature/mail/auth.go)(授权)
+
+> ⚠️ 这**不是**一个自动注册的 `contracts.Features`(不走 `AddFeature`、不读 env)。它是一个库,由 app 按需构造。旧的 `feature.NewMailFeature` / `EmailService` / `config.MailConfig`(从 `MAIL_SMTP_*` 读配置)已移除,见文末「从旧版迁移」。
 
 ---
 
-## 创建 & 用法
+## 核心
 
 ```go
-app.AddFeature(feature.NewMailFeature())
-```
+type Message struct {
+    From    string   // 可选;为空则用供应商默认 From(SMTP 见 WithFrom)
+    To, Cc, Bcc []string
+    Subject string
+    Text    string   // 纯文本正文
+    HTML    string   // 可选 HTML 正文
+}
 
-以接口 `EmailService` 注入([feature/mail.go:43](../../feature/mail.go#L43)):
-
-```go
-type EmailService interface {
-    SendText(ctx, to []string, subject, body string) error
-    SendHTML(ctx, to []string, subject, htmlBody string) error
-    Send(ctx, to []string, subject, textBody, htmlBody string) error   // 同时带 text+html
+// 调用方依赖这个;换实现(供应商/授权)都不动调用点。
+type Mailer interface {
+    Send(ctx context.Context, msg Message) error
 }
 ```
 
-行为([feature/mail.go:80](../../feature/mail.go#L80) `send`):
-- From 头:有 `MAIL_FROM_NAME` 时为 `Name <email>`,否则纯 email;
-- text+html 都给 → `text/plain` 正文 + `text/html` alternative;只给一个 → 对应类型;两个都空 → 报错;
-- 底层 `dialer.DialAndSend`。
+**内容规则**:只 `Text` → `text/plain`;只 `HTML` → `text/html`;**两者都给 → `multipart/alternative`**(纯文本回退 + HTML);都空 → 报错。`From` 解析后为空也报错(避免发出去被服务器拒)。
 
-> ⚠️ 接口签名带 `ctx context.Context`,但**实际发信没用到 ctx**(不支持超时/取消)。
+---
 
-## 环境变量 —— 全部强制必填(FromName 除外)
+## SMTP 供应商
 
-`MailConfig.Validate` 强制校验([config/mail.go:16](../../config/mail.go#L16)),缺任一 → `Setup` 失败、进程不启动:
+```go
+m := mail.NewSMTP("smtp.gmail.com", 587,
+    mail.WithFrom("me@gmail.com"),
+    mail.WithAuth(mail.BasicAuth("me@gmail.com", "<app-password>")),
+    mail.WithTimeout(15*time.Second),   // 可选,默认 10s
+)
 
-| Env | 字段 | 必填 | 说明 |
-|---|---|---|---|
-| `MAIL_SMTP_HOST` | SMTPHost | ✅ | SMTP 主机 |
-| `MAIL_SMTP_PORT` | SMTPPort | ✅ | int,1–65535 |
-| `MAIL_SMTP_USER` | SMTPUser | ✅ | 用户名 |
-| `MAIL_SMTP_PASSWORD` | SMTPPassword | ✅ | 密码 |
-| `MAIL_FROM_EMAIL` | FromEmail | ✅ | 发件邮箱 |
-| `MAIL_FROM_NAME` | FromName | ❌(omitempty) | 发件人显示名 |
+err := m.Send(ctx, mail.Message{
+    To:      []string{"user@example.com"},
+    Subject: "Hello",
+    Text:    "plain body",
+    HTML:    "<b>html body</b>",
+})
+```
 
-> ⚠️ 因为**强制必填**,即使某服务不真的发信,也得给这些 env 填占位值(否则起不来)。homeserver 就用 `noop.invalid` 之类占位过校验。若希望"可选发信",要改成把这些字段标 `omitempty` 并在发信处判空 —— 当前实现不支持。
+- `NewSMTP(host, port, ...SMTPOption)`:host+port 必填;`WithFrom` / `WithAuth` / `WithTimeout` 为可选项。
+- 端口自动判加密:`465` = 隐式 TLS,其余(如 `587`)= STARTTLS。
+- **ctx 生效**:`Send` 把底层发送放到 goroutine,`ctx` 取消/超时会让**调用方立即返回**(`ctx.Err()`);后台拨号由 `WithTimeout` 兜底。
+
+---
+
+## 授权(可插拔、对外开放)
+
+```go
+mail.BasicAuth(username, password)   // 账号+密码(PLAIN/LOGIN),最常见
+mail.NoAuth()                        // 无鉴权(内网中继)
+mail.XOAuth2(username, tokenSource)  // OAuth2 Bearer(SASL XOAUTH2),Gmail/Outlook/O365 现代认证
+```
+
+`XOAuth2` 的 token 每次发送现取(带 ctx),短时 token 不会过期:
+
+```go
+mail.XOAuth2("me@outlook.com", func(ctx context.Context) (string, error) {
+    return oauthClient.AccessToken(ctx)   // 你的 token 逻辑
+})
+```
+
+### 加一种自己的授权方式
+
+授权是**开放**的:实现 `SMTPAuth`(只依赖本接口 + 标准库 `net/smtp`,**不碰底层 SMTP 库**):
+
+```go
+type SMTPAuth interface {
+    Apply(ctx context.Context, d SMTPDialer) error
+}
+type SMTPDialer interface {
+    SetBasic(username, password string)          // 账号+密码
+    SetMechanism(username string, mech smtp.Auth) // 自定义 SASL 机制
+}
+
+// 例:自定义机制
+type myAuth struct{ user string }
+func (a myAuth) Apply(ctx context.Context, d mail.SMTPDialer) error {
+    d.SetMechanism(a.user, myMechanism{...}) // myMechanism 实现 net/smtp.Auth
+    return nil
+}
+// 用:mail.NewSMTP(host, port, mail.WithAuth(myAuth{...}))
+```
+
+---
+
+## 加一个新供应商
+
+每个供应商就是一个返回 `Mailer` 的构造器。要接阿里云邮件推送 / AWS SES / SendGrid,新增一个实现即可(建议放子包如 `feature/mail/aliyun`、`feature/mail/ses`,让各自的 SDK 依赖不污染核心):
+
+```go
+package aliyun
+func New(cfg Config) mail.Mailer { /* 实现 Send:调阿里云 DirectMail API */ }
+```
+
+调用方只认 `mail.Mailer`,换供应商零改动。
+
+---
+
+## 从旧版迁移(破坏性变更)
+
+旧的 `feature.NewMailFeature()` / `EmailService`(`SendText/SendHTML/Send`)/ `config.MailConfig`(从 `MAIL_SMTP_*` env 读、`bootstrap` 自动注册)**已删除**。迁移:
+
+| 旧 | 新 |
+|---|---|
+| `app.AddFeature(feature.NewMailFeature())` + 注入 `EmailService` | 直接 `mail.NewSMTP(host, port, opts...)` 构造 `Mailer` |
+| 配 `MAIL_SMTP_*` env | 配置来源交给 app(env / DB / 临时),自己读出来传给 `NewSMTP` / `WithAuth` |
+| `svc.SendText(ctx, to, subject, body)` | `m.Send(ctx, mail.Message{To: to, Subject: subject, Text: body})` |
+| `SendHTML` | `Send(..., Message{HTML: ...})` |
+| ctx 不生效 | ctx 生效(可取消/超时) |
+
+`bootstrap.InitDefaultApp` 不再自动注册邮件。

--- a/sample/full_showcase/.env
+++ b/sample/full_showcase/.env
@@ -89,22 +89,9 @@ I18N_LOCALE_DIR=locales
 # I18N_LOAD_EMBEDDED=true
 
 # ============================================
-# Mail Configuration (optional; omit if not using mail)
+# Mail
 # ============================================
-# SMTP host
-# MAIL_SMTP_HOST=smtp.gmail.com
-
-# SMTP port
-# MAIL_SMTP_PORT=587
-
-# Sender email
-# MAIL_FROM_EMAIL=noreply@example.com
-
-# Sender name
-# MAIL_FROM_NAME=Sample Service
-
-# SMTP username
-# MAIL_SMTP_USER=your_email@gmail.com
-
-# SMTP password (or app password)
-# MAIL_SMTP_PASSWORD=your_app_password
+# Mail is no longer env-configured. Construct a mailer in code with your own config source:
+#   m := mail.NewSMTP(host, port, mail.WithFrom(from), mail.WithAuth(mail.BasicAuth(user, pass)))
+#   m.Send(ctx, mail.Message{To: []string{...}, Subject: ..., Text: ...})
+# See doc/features/mail.md.


### PR DESCRIPTION
Follow-up to #40 — that PR replaced the mail feature but left `doc/features/mail.md` describing the old env-based `EmailService`.

Rewrites `doc/features/mail.md` for the new `feature/mail` package:
- `Message` + `Mailer`; content rules (text/html/both → multipart).
- `NewSMTP(host, port, WithFrom/WithAuth/WithTimeout)`; **ctx is honored** (cancellable send).
- Auth: `BasicAuth` / `NoAuth` / `XOAuth2`, and **how to add your own** via the open `SMTPAuth` + `SMTPDialer` (no dependency on the concrete SMTP lib).
- How to add a new provider (Aliyun/SES/… as further `Mailer` impls).
- A **migration table** from the removed `NewMailFeature` / `EmailService` / `MAIL_SMTP_*`.

Docs-only.