### PR TITLE
feat(mail): configurable SMTP transport encryption (auto/none/starttls/ssl)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ Aurora 是一个约定优于配置的 Go 后端框架:把「HTTP 服务器 + 数
 | [redis](./features/redis.md) | Redis 封装、分布式锁 | `WithLock` 是 skip-if-running;`REDIS_PASSWORD` 强制非空 |
 | [jwt](./features/jwt.md) | access/refresh token、黑名单登出 | jti;黑名单 TTL=剩余寿命;Redis 故障 fail-open |
 | [i18n](./features/i18n.md) | 多语言翻译 | 请求语言:`?lang=`>Accept-Language;`LoadEmbedded` 未用 |
-| [mail](./features/mail.md) | 发信(供应商无关,SMTP + 可插拔授权) | **不是 Feature**:不走 `AddFeature`、不读 env;`mail.NewSMTP(...)` 按需构造 |
+| [mail](./features/mail.md) | 发信(供应商无关,SMTP + 可插拔授权 + 可配加密) | **不是 Feature**:不走 `AddFeature`、不读 env;`mail.NewSMTP(...)` 按需构造 |
 | [migration](./features/migration.md) | goose 迁移 | `GOOSE_TABLE_PREFIX` 隔离共库版本表;worker 别跑迁移 |
 | [错误模型 & 日志](./features/bizerr.md) | bizerr / logger | 默认响应只含 message;LOG_LEVEL>RUN_LEVEL |
 

--- a/doc/features/mail.md
+++ b/doc/features/mail.md
@@ -47,8 +47,11 @@ err := m.Send(ctx, mail.Message{
 })
 ```
 
-- `NewSMTP(host, port, ...SMTPOption)`:host+port 必填;`WithFrom` / `WithAuth` / `WithTimeout` 为可选项。
-- 端口自动判加密:`465` = 隐式 TLS,其余(如 `587`)= STARTTLS。
+- `NewSMTP(host, port, ...SMTPOption)`:host+port 必填;`WithFrom` / `WithAuth` / `WithTimeout` / `WithEncryption` 为可选项。
+- 加密方式:`WithEncryption` 显式指定,不设 = **自动**(`EncryptionAuto`,零值):`465` = 隐式 TLS(SSL),其余端口机会式 STARTTLS(服务器不支持则明文降级)。显式取值:
+  - `EncryptionNone` —— 明文,禁用 STARTTLS;
+  - `EncryptionStartTLS` —— 强制 STARTTLS(不支持即报错);
+  - `EncryptionSSL` —— 强制隐式 TLS on connect(不看端口)。
 - **ctx 生效**:`Send` 把底层发送放到 goroutine,`ctx` 取消/超时会让**调用方立即返回**(`ctx.Err()`);后台拨号由 `WithTimeout` 兜底。
 
 ---

--- a/feature/mail/smtp.go
+++ b/feature/mail/smtp.go
@@ -17,6 +17,25 @@ var (
 
 const defaultSMTPTimeout = 10 * time.Second
 
+// Encryption selects how the SMTP transport is secured. Empty ("") == EncryptionAuto, which
+// preserves gomail's historical behaviour (SSL-on-connect only when port==465, otherwise
+// opportunistic STARTTLS that silently falls back to plaintext). Set an explicit value to force
+// a mode regardless of port.
+type Encryption string
+
+const (
+	// EncryptionAuto keeps gomail defaults: SSL iff port==465, else opportunistic STARTTLS with
+	// plaintext fallback. This is the zero value, so existing callers are unaffected.
+	EncryptionAuto Encryption = ""
+	// EncryptionNone sends over plaintext and disables STARTTLS entirely (no encryption).
+	EncryptionNone Encryption = "none"
+	// EncryptionStartTLS mandates STARTTLS: connect in plaintext then upgrade; fail if the server
+	// does not advertise STARTTLS.
+	EncryptionStartTLS Encryption = "starttls"
+	// EncryptionSSL forces implicit TLS on connect (SMTPS), regardless of port.
+	EncryptionSSL Encryption = "ssl"
+)
+
 // SMTPOption configures the SMTP mailer (functional options).
 type SMTPOption func(*smtpMailer)
 
@@ -30,12 +49,17 @@ func WithAuth(a SMTPAuth) SMTPOption { return func(m *smtpMailer) { m.auth = a }
 // send is cancelled via context.
 func WithTimeout(d time.Duration) SMTPOption { return func(m *smtpMailer) { m.timeout = d } }
 
+// WithEncryption forces the transport security mode. Omit (or pass EncryptionAuto) to keep the
+// port-based auto behaviour.
+func WithEncryption(e Encryption) SMTPOption { return func(m *smtpMailer) { m.encryption = e } }
+
 type smtpMailer struct {
-	host    string
-	port    int
-	from    string
-	auth    SMTPAuth
-	timeout time.Duration
+	host       string
+	port       int
+	from       string
+	auth       SMTPAuth
+	timeout    time.Duration
+	encryption Encryption
 }
 
 // NewSMTP builds a Mailer that sends over SMTP (Gmail / Outlook / any host). host+port are
@@ -62,6 +86,20 @@ func (s *smtpMailer) Send(ctx context.Context, msg Message) error {
 
 	d := gomail.NewDialer(s.host, s.port, "", "")
 	d.Timeout = s.timeout
+	// Transport security. EncryptionAuto leaves gomail's port-based defaults (SSL iff port==465,
+	// else opportunistic STARTTLS). Explicit modes override regardless of port.
+	switch s.encryption {
+	case EncryptionSSL:
+		d.SSL = true
+	case EncryptionStartTLS:
+		d.SSL = false
+		d.StartTLSPolicy = gomail.MandatoryStartTLS
+	case EncryptionNone:
+		d.SSL = false
+		d.StartTLSPolicy = gomail.NoStartTLS
+	case EncryptionAuto:
+		// keep gomail defaults
+	}
 	if s.auth != nil {
 		if err := s.auth.Apply(ctx, (*dialerAdapter)(d)); err != nil {
 			return err

--- a/feature/mail/smtp_test.go
+++ b/feature/mail/smtp_test.go
@@ -44,6 +44,20 @@ func TestSMTPOptions_ApplyAndDefaults(t *testing.T) {
 	}
 }
 
+// TestWithEncryption proves the encryption option is applied and defaults to auto (empty),
+// which keeps gomail's port-based behaviour for existing callers.
+func TestWithEncryption(t *testing.T) {
+	// Default: no option -> EncryptionAuto ("").
+	if m := NewSMTP("h", 25).(*smtpMailer); m.encryption != EncryptionAuto {
+		t.Errorf("default encryption = %q, want auto (empty)", m.encryption)
+	}
+	for _, enc := range []Encryption{EncryptionNone, EncryptionStartTLS, EncryptionSSL} {
+		if m := NewSMTP("h", 25, WithEncryption(enc)).(*smtpMailer); m.encryption != enc {
+			t.Errorf("WithEncryption(%q): got %q", enc, m.encryption)
+		}
+	}
+}
+
 // TestSend_AuthErrorAbortsBeforeDial proves WithAuth is wired into Send and that an auth failure
 // aborts the send before any network I/O (here: XOAuth2 whose token fetch fails).
 func TestSend_AuthErrorAbortsBeforeDial(t *testing.T) {


### PR DESCRIPTION
## 背景
`feature/mail` 的 SMTP 发信目前完全依赖 gomail 的默认加密策略:端口 465 才走 SSL-on-connect,其它端口用机会式 STARTTLS(不支持则明文降级)。调用方**无法显式指定加密方式** —— 尤其是「无加密」的邮件服务器,或想强制 STARTTLS/SSL 的场景,都没有出口。

## 改动
新增 `WithEncryption(Encryption)` 这个 SMTP 选项,让调用方显式选择传输加密方式,并在 `Send()` 里应用到 gomail dialer:

| 取值 | 行为 |
|---|---|
| `EncryptionAuto`(`""`,零值) | **保持现状**:465 走 SSL,其它端口机会式 STARTTLS + 明文降级。**存量调用方零影响。** |
| `EncryptionNone`(`"none"`) | 明文,禁用 STARTTLS(`NoStartTLS`)—— 面向无加密服务器 |
| `EncryptionStartTLS`(`"starttls"`) | 强制 STARTTLS(`MandatoryStartTLS`),不支持即报错 |
| `EncryptionSSL`(`"ssl"`) | 连接即隐式 TLS(SMTPS),不看端口 |

## 兼容性
- `Encryption` 的零值是 `EncryptionAuto`,`smtpMailer` 不设该选项时行为与改动前**完全一致**,现有调用方不需要任何改动。
- 纯增量:新增一个类型 + 一个 functional option + `Send()` 里一个 switch,未改任何现有签名。

## 测试
新增 `TestWithEncryption`:验证选项被正确应用、且默认值为 auto(空)。`go test ./feature/mail/` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)